### PR TITLE
fix color styles for buttons

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -288,8 +288,6 @@ body {
 }
 
 .admin-link:hover {
-  background: var(--text);
-  color: #fff;
   border-color: var(--text);
 }
 
@@ -643,7 +641,7 @@ body {
 }
 
 .btn-primary {
-  background: var(--text);
+  background: var(--accent);
   color: #fff;
 }
 


### PR DESCRIPTION

### Overview

Cuando le haces hover al botón de `Comparar` en dark theme, se pone todo gris:
<img width="414" height="186" alt="image" src="https://github.com/user-attachments/assets/103fe857-bfc2-4316-8dac-b3f805fe134a" />
 -> 
<img width="398" height="182" alt="image" src="https://github.com/user-attachments/assets/8401590a-6a13-4082-b3c5-82845d7b68f4" />

Esta rama cambia el style que usa el botón para que se vea asi on hover:
<img width="440" height="192" alt="image" src="https://github.com/user-attachments/assets/4d299cd1-8f62-488f-8fca-8d5fbf9048bf" />

-----------------------------------------------------------------------------------------
También, el botón de `Comparar` de esa página se ve asi:
<img width="560" height="374" alt="image" src="https://github.com/user-attachments/assets/fada3cbf-dbbc-4170-8451-6622139ec574" />

Asi que cambié el style para que se vea asi:
Dark theme: <img width="326" height="244" alt="image" src="https://github.com/user-attachments/assets/b8ff1195-af5f-4e0e-a526-b19347d81294" />

Light theme: 
<img width="246" height="146" alt="image" src="https://github.com/user-attachments/assets/9ac8b1d7-070d-4dc6-bc43-1fde62b53fd1" />

Siguiendo el style de los otros botones de la página.