### PR TITLE
Dogfood: fix OG images, add hash routing, fix mixed content, mobile header

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+## Proyecto
+
+Rendimientos AR - Sitio para comparar rendimientos de productos financieros en Argentina y monitorear mercados globales. Live en [rendimientos.co](https://rendimientos.co).
+
+## Stack
+
+- **Frontend**: Vanilla JS + CSS (no framework), Chart.js para graficos
+- **Backend**: Express.js (local dev), Netlify Functions (prod)
+- **Datos**: ArgentinaDatos API (FCIs, Plazo Fijo), data912 (LECAPs, CEDEARs, Bonos), Yahoo Finance (Monitor Global, CEDEARs USD), Google News RSS
+- **Deploy**: Netlify (`npx netlify deploy --prod`)
+- **Dominio**: rendimientos.co (canonical), rendimientos-ar.netlify.app (legacy)
+
+## Estructura clave
+
+- `public/index.html` - SPA con 4 secciones: Mundo, ARS, CEDEARs, Bonos
+- `public/app.js` - Toda la logica del frontend
+- `public/config.json` - Config estatica (billeteras, ratios CEDEARs, flujos bonos)
+- `public/styles.css` - Estilos + dark mode con CSS variables
+- `server.js` - Server Express para dev local
+- `netlify/functions/` - Funciones serverless (proxies de APIs)
+
+## Desarrollo local
+
+```bash
+npm install && npm start  # http://localhost:3000
+```
+
+Nota: Las Netlify functions (mundo, cedears, soberanos, news) solo funcionan en produccion. El server local sirve FCIs y config.
+
+## Reglas
+
+- Mantener el sitio vanilla (sin frameworks JS/CSS)
+- Respetar el sistema de temas dark/light con CSS variables
+- Los logos de bancos vienen de BCRA (http -> siempre upgradar a https)
+- Los datos de billeteras/cuentas remuneradas son manuales en config.json
+- El SEO usa el dominio `rendimientos.co`, no el legacy de Netlify
+
+---
+
+## Prompts para agentes
+
+Prompts listos para usar con Claude Code u otros agentes AI para operar sobre este repo.
+
+### Actualizar tasas de billeteras
+
+```
+Lee public/config.json y actualiza las TNA de las billeteras/cuentas remuneradas
+que hayan cambiado. Los datos estan en la seccion "garantizados".
+Cada entrada tiene: nombre, tipo, limite, tna, vigente_desde.
+Actualiza vigente_desde a la fecha de hoy en formato DD/MM/YYYY.
+No modifiques entradas cuya tasa no cambio.
+
+Billeteras a actualizar:
+- [nombre]: [nueva TNA]%
+```
+
+### Agregar nueva billetera/cuenta remunerada
+
+```
+Agrega una nueva entrada en public/config.json, seccion "garantizados".
+Sigue el formato existente. El campo "id" es kebab-case del nombre.
+Si tiene logo propio, agrega el mapping en ENTITY_LOGOS en public/app.js.
+Si tiene condiciones especiales, ponerlo en la seccion "especiales" en vez de "garantizados".
+
+Datos:
+- Nombre: [nombre]
+- Tipo: Billetera | Cuenta Remunerada
+- Limite: [ej: $1 M]
+- TNA: [numero]
+- Vigente desde: [DD/MM/YYYY]
+- Logo (2 letras): [XX]
+- Color logo: [hex]
+```
+
+### Agregar nuevo CEDEAR
+
+```
+Agrega un nuevo CEDEAR a la tabla de ratios en public/config.json, seccion "cedears_ratios".
+El formato es: { "ticker": "XXXX", "ratio": N }
+donde ratio es la cantidad de CEDEARs que equivalen a 1 ADR.
+
+Datos:
+- Ticker: [ticker en BYMA]
+- Ratio: [numero, ej: 5 significa 5:1]
+```
+
+### Agregar nuevo bono soberano
+
+```
+Agrega un nuevo bono soberano en public/config.json, seccion "soberanos".
+Necesitas los flujos de fondos futuros (cupon + amortizacion) por cada 100 VN.
+Sigue el formato de los bonos existentes (AL30, GD30, etc).
+
+Datos:
+- Ticker (local): [ej: AL30]
+- Ticker data912 (con D): [ej: AL30D]
+- Ley: Local | NY
+- Vencimiento: [YYYY-MM-DD]
+- Flujos: [lista de {fecha, cupon, amortizacion}]
+```
+
+### Actualizar LECAPs/BONCAPs
+
+```
+Los LECAPs y BONCAPs se leen de public/config.json, seccion "lecaps".
+Cuando se emite una nueva LECAP/BONCAP, agrega la entrada con:
+- ticker: [ej: S17A6]
+- tipo: LECAP | BONCAP
+- vencimiento: [YYYY-MM-DD]
+- pago_final: [monto por 100 VN]
+
+Los precios se obtienen en vivo de data912, no hace falta actualizar precios.
+```
+
+### Dogfood / QA del sitio
+
+```
+Navega https://rendimientos.co/ como un usuario real.
+Revisa cada seccion: Mundo, ARS (Billeteras, Plazo Fijo, LECAPs), CEDEARs, Bonos.
+Busca:
+- Links rotos o que no funcionan
+- Datos desactualizados o inconsistentes
+- Problemas visuales en mobile y desktop
+- Errores en consola del browser
+- Problemas de accesibilidad (contraste, labels, keyboard nav)
+- SEO (meta tags, OG, canonical)
+Documenta cada hallazgo con severidad, categoria y pasos para reproducir.
+```
+
+### Deploy
+
+```
+Ejecuta `npx netlify deploy --prod` desde la raiz del repo.
+Verifica que el sitio cargue correctamente en https://rendimientos.co/
+```
+
+### Revisar rendimiento
+
+```
+Analiza el rendimiento del sitio:
+1. Lee public/app.js y public/styles.css
+2. Identifica:
+   - Requests innecesarios o redundantes
+   - Archivos grandes que podrian lazy-loadear
+   - CSS que bloquea renderizado
+   - Imagenes sin optimizar
+3. Sugiere mejoras concretas con codigo.
+```

--- a/public/app.js
+++ b/public/app.js
@@ -174,10 +174,11 @@ function renderRendimientosChart(items, containerId) {
     const chartMin = 10;
     const pct = Math.max(8, ((item.tna - chartMin) / (maxTna - chartMin)) * 100);
     const color = getBarColor(item.tna);
-    const logoInner = item.logoSrc
-      ? `<img src="${item.logoSrc}" alt="${item.nombre}" onerror="this.parentElement.textContent='${item.logo}'">`
+    const safeChartLogoSrc = item.logoSrc?.replace(/^http:\/\//, 'https://');
+    const logoInner = safeChartLogoSrc
+      ? `<img src="${safeChartLogoSrc}" alt="${item.nombre}" onerror="this.parentElement.textContent='${item.logo}'">`
       : item.logo;
-    const logoBg = item.logoSrc ? 'transparent' : item.logoBg;
+    const logoBg = safeChartLogoSrc ? 'transparent' : item.logoBg;
 
     return `
       <div class="chart-row">
@@ -207,12 +208,14 @@ function createCard({ logo, logoBg, logoSrc, name, entity, description, tags, ra
   const entityHTML = entity ? `<div class="fund-entity">${entity}</div>` : '';
 
   // Use real logo image if available, otherwise fallback to initials
-  const logoInner = logoSrc
-    ? `<img src="${logoSrc}" alt="${name}">`
+  // Fix mixed content: upgrade http:// to https:// for BCRA logos
+  const safeLogoSrc = logoSrc?.replace(/^http:\/\//, 'https://');
+  const logoInner = safeLogoSrc
+    ? `<img src="${safeLogoSrc}" alt="${name}">`
     : logo;
 
   card.innerHTML = `
-    <div class="fund-logo" style="background:${logoSrc ? 'transparent' : logoBg}">${logoInner}</div>
+    <div class="fund-logo" style="background:${safeLogoSrc ? 'transparent' : logoBg}">${logoInner}</div>
     <div class="fund-info">
       <div class="fund-name">${name}</div>
       ${entityHTML}
@@ -227,7 +230,7 @@ function createCard({ logo, logoBg, logoSrc, name, entity, description, tags, ra
   `;
 
   // Add error handler for logo images
-  if (logoSrc) {
+  if (safeLogoSrc) {
     const img = card.querySelector('.fund-logo img');
     if (img) {
       img.onerror = function() {
@@ -344,6 +347,8 @@ function setupTabs() {
         hero.querySelector('h1').textContent = 'Rendimientos de Fondos y Billeteras';
         hero.querySelector('p').textContent = 'Compará rendimientos actualizados de billeteras y fondos de liquidez en Argentina.';
       }
+      // Update hash for sub-tabs
+      location.hash = target === 'billeteras' ? 'ars' : target;
     });
   });
 
@@ -365,6 +370,19 @@ function setupTabs() {
     document.getElementById('tab-soberanos').style.display = 'none';
     document.getElementById('section-mundo').style.display = 'none';
     [headerArs, headerCedears, headerSoberanos, headerMundo].forEach(b => b && b.classList.remove('active'));
+  }
+
+  function updatePageTitle(section) {
+    const base = 'Rendimientos AR';
+    const titles = {
+      mundo: 'Monitor Global',
+      ars: 'Billeteras y Fondos',
+      cedears: 'Arbitraje CEDEARs',
+      bonos: 'Bonos Soberanos USD',
+      plazofijo: 'Tasas Plazo Fijo',
+      lecaps: 'LECAPs y BONCAPs'
+    };
+    document.title = titles[section] ? `${titles[section]} — ${base}` : base;
   }
 
   function switchToArs() {
@@ -395,6 +413,8 @@ function setupTabs() {
       hero.querySelector('h1').textContent = 'Rendimientos de Fondos y Billeteras';
       hero.querySelector('p').textContent = 'Compará rendimientos actualizados de billeteras y fondos de liquidez en Argentina.';
     }
+    const sub = document.querySelector('.subnav-tab.active')?.dataset.tab || 'ars';
+    updatePageTitle(sub === 'billeteras' ? 'ars' : sub);
   }
 
   function switchToCedears() {
@@ -404,6 +424,7 @@ function setupTabs() {
     document.getElementById('tab-cedears').style.display = '';
     hero.querySelector('h1').textContent = 'Arbitraje de CEDEARs';
     hero.querySelector('p').textContent = 'CCL implícito por CEDEAR y spread vs tipo de cambio de referencia.';
+    updatePageTitle('cedears');
     if (!document.getElementById('cedears-list').hasChildNodes()) {
       loadCedears();
     }
@@ -416,6 +437,7 @@ function setupTabs() {
     document.getElementById('tab-soberanos').style.display = '';
     hero.querySelector('h1').textContent = 'Bonos Soberanos USD';
     hero.querySelector('p').textContent = 'Rendimiento de bonos soberanos argentinos en dólares. Ley local y ley extranjera.';
+    updatePageTitle('bonos');
     if (!document.getElementById('soberanos-list').hasChildNodes()) {
       loadSoberanos();
     }
@@ -428,15 +450,35 @@ function setupTabs() {
     document.getElementById('section-mundo').style.display = '';
     hero.querySelector('h1').textContent = 'Monitor Global';
     hero.querySelector('p').textContent = 'Principales indicadores del mercado mundial en tiempo real.';
+    updatePageTitle('mundo');
     if (!document.getElementById('mundo-grid').hasChildNodes()) {
       loadMundo();
     }
   }
 
-  if (headerArs) headerArs.addEventListener('click', (e) => { e.preventDefault(); switchToArs(); });
-  if (headerCedears) headerCedears.addEventListener('click', (e) => { e.preventDefault(); switchToCedears(); });
-  if (headerSoberanos) headerSoberanos.addEventListener('click', (e) => { e.preventDefault(); switchToSoberanos(); });
-  if (headerMundo) headerMundo.addEventListener('click', (e) => { e.preventDefault(); switchToMundo(); });
+  if (headerArs) headerArs.addEventListener('click', (e) => { e.preventDefault(); switchToArs(); location.hash = 'ars'; });
+  if (headerCedears) headerCedears.addEventListener('click', (e) => { e.preventDefault(); switchToCedears(); location.hash = 'cedears'; });
+  if (headerSoberanos) headerSoberanos.addEventListener('click', (e) => { e.preventDefault(); switchToSoberanos(); location.hash = 'bonos'; });
+  if (headerMundo) headerMundo.addEventListener('click', (e) => { e.preventDefault(); switchToMundo(); location.hash = 'mundo'; });
+
+  // Handle initial hash on page load
+  const initialHash = location.hash.replace('#', '');
+  if (initialHash === 'ars') switchToArs();
+  else if (initialHash === 'cedears') switchToCedears();
+  else if (initialHash === 'bonos') switchToSoberanos();
+  else if (initialHash === 'plazofijo') { switchToArs(); document.querySelector('.subnav-tab[data-tab="plazofijo"]')?.click(); }
+  else if (initialHash === 'lecaps') { switchToArs(); document.querySelector('.subnav-tab[data-tab="lecaps"]')?.click(); }
+
+  // Handle back/forward navigation
+  window.addEventListener('hashchange', () => {
+    const h = location.hash.replace('#', '');
+    if (h === 'ars') switchToArs();
+    else if (h === 'cedears') switchToCedears();
+    else if (h === 'bonos') switchToSoberanos();
+    else if (h === 'plazofijo') { switchToArs(); document.querySelector('.subnav-tab[data-tab="plazofijo"]')?.click(); }
+    else if (h === 'lecaps') { switchToArs(); document.querySelector('.subnav-tab[data-tab="lecaps"]')?.click(); }
+    else switchToMundo();
+  });
 }
 
 // ─── Plazo Fijo section ───

--- a/public/index.html
+++ b/public/index.html
@@ -11,7 +11,7 @@
   <meta property="og:url" content="https://rendimientos.co/">
   <meta property="og:title" content="Rendimientos AR — Compará billeteras, fondos y plazos fijos">
   <meta property="og:description" content="Compará rendimientos actualizados de billeteras digitales, fondos de inversión y plazos fijos en Argentina. Datos de CAFCI y BCRA.">
-  <meta property="og:image" content="https://rendimientos-ar.netlify.app/og-image.png">
+  <meta property="og:image" content="https://rendimientos.co/og-image.png">
   <meta property="og:image:width" content="1200">
   <meta property="og:image:height" content="630">
   <meta property="og:site_name" content="Rendimientos AR">
@@ -21,7 +21,7 @@
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Rendimientos AR — Compará billeteras, fondos y plazos fijos">
   <meta name="twitter:description" content="Compará rendimientos actualizados de billeteras digitales, fondos de inversión y plazos fijos en Argentina.">
-  <meta name="twitter:image" content="https://rendimientos-ar.netlify.app/og-image.png">
+  <meta name="twitter:image" content="https://rendimientos.co/og-image.png">
 
   <link rel="canonical" href="https://rendimientos.co/">
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>💰</text></svg>">

--- a/public/styles.css
+++ b/public/styles.css
@@ -936,15 +936,17 @@ body {
 /* Responsive */
 @media (max-width: 640px) {
   .header-inner {
-    padding: 10px 16px;
-    gap: 8px;
+    padding: 8px 12px;
+    gap: 6px;
     overflow-x: auto;
     -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
   }
   .header-inner::-webkit-scrollbar { display: none; }
-  .logo { font-size: 0.85rem; white-space: nowrap; }
-  .currency-tabs { flex-shrink: 0; }
-  .currency-tab { padding: 5px 10px; font-size: 0.72rem; }
+  .logo { font-size: 0.8rem; white-space: nowrap; flex-shrink: 0; }
+  .currency-tabs { flex-shrink: 0; gap: 0; padding: 2px; }
+  .currency-tab { padding: 4px 6px; font-size: 0.65rem; }
+  .currency-tab .flag { display: none; }
   .admin-link { display: none; }
   .subnav-inner { padding: 0 16px; }
   .hero { padding: 16px 16px 8px; }


### PR DESCRIPTION
## Summary

Resultado de un dogfood completo del sitio [rendimientos.co](https://rendimientos.co). Se encontraron 9 issues (3 high, 4 medium, 2 low) y este PR resuelve los 5 más impactantes:

- **Fix og:image y twitter:image** que apuntaban al dominio viejo `rendimientos-ar.netlify.app` en vez de `rendimientos.co` — afecta previews en WhatsApp, Twitter, Slack
- **Hash routing para tabs** (`#ars`, `#cedears`, `#bonos`, `#plazofijo`, `#lecaps`) con soporte de deep linking, back/forward del browser, y título de página dinámico por tab — mejora SEO y shareability
- **Fix mixed content**: 58 logos de bancos cargaban via `http://` desde BCRA, ahora se upgradan a `https://` automáticamente
- **Mobile header fix**: en viewports de 375px el header desbordaba (618px → 375px) — se ocultan emojis de flags y se ajusta spacing
- **CLAUDE.md** con contexto del proyecto y **prompts listos para agentes** para operaciones comunes (actualizar tasas, agregar billeteras/CEDEARs/bonos, dogfood, deploy, etc.)

## Issues encontrados (reporte completo)

| # | Severidad | Issue |
|---|-----------|-------|
| 001 | 🔴 High | OG/Twitter image URLs apuntan a dominio viejo Netlify → **FIXED** |
| 002 | 🔴 High | 58 imágenes cargadas via HTTP (mixed content) → **FIXED** |
| 003 | 🔴 High | Header nav overflow en mobile (618px en 375px viewport) → **FIXED** |
| 004 | 🟡 Medium | Heading duplicado "Monitor Global" (H1 + H2) |
| 005 | 🟡 Medium | Sin URL routing / deep linking para tabs → **FIXED** |
| 006 | 🟡 Medium | Ualá en Plazo Fijo muestra fallback "UA" en vez de logo |
| 007 | 🟡 Medium | Algunos bancos sin tag "Plazo Fijo Online" (data issue) |
| 008 | 🟢 Low | News ticker con items duplicados (esperado para marquee infinito) |
| 009 | 🟢 Low | Visit counter muestra número estático |

## Archivos modificados

- `public/index.html` — Fix meta tags OG/Twitter
- `public/app.js` — Hash routing, page titles, HTTPS upgrade para logos
- `public/styles.css` — Mobile header responsive fix
- `CLAUDE.md` — **Nuevo**: contexto del proyecto + prompts para agentes

## Test plan

- [x] Verificar OG image apunta a `rendimientos.co/og-image.png`
- [x] Verificar deep linking: abrir `/#cedears` carga la sección correcta
- [x] Verificar back/forward del browser entre tabs
- [x] Verificar título de página se actualiza por tab
- [x] Verificar 0 imágenes HTTP en Plazo Fijo (todas HTTPS)
- [x] Verificar header no desborda en viewport 375px
- [x] Verificar desktop no afectado (flags visibles, font normal)
- [x] Verificar no hay errores nuevos en consola

🤖 Generated with [Claude Code](https://claude.com/claude-code)