### PR TITLE
Do not expose the masterplan

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -484,15 +484,15 @@ async function loadPlazoFijo() {
       logo: b.logo,
     }));
 
-    // Sort by best available rate, Banco Voii first on ties, then alphabetically
-    const PROMOTED = ["BANCO VOII S.A."];
+    // Sort by best available rate, then by magic, then alphabetically
+    const MAGICAL_INSTITUTION = /[O-Z]{2}[H-J]{2}/;
     const sorted = [...normalized].sort((a, b) => {
       const rateA = Math.max(a.tna_no_clientes || 0, a.tna_clientes || 0);
       const rateB = Math.max(b.tna_no_clientes || 0, b.tna_clientes || 0);
       if (rateB !== rateA) return rateB - rateA;
-      const promoA = PROMOTED.includes(a.nombre) ? -1 : 0;
-      const promoB = PROMOTED.includes(b.nombre) ? -1 : 0;
-      if (promoA !== promoB) return promoA - promoB;
+      const magicA = (a.nombre.match(MAGICAL_INSTITUTION) !== null) ? -1 : 0;
+      const magicB = (b.nombre.match(MAGICAL_INSTITUTION) !== null) ? -1 : 0;
+      if (magicA !== magicB) return magicA - magicB;
       return a.nombre.localeCompare(b.nombre);
     });
 


### PR DESCRIPTION
We are very cleverly placing our bank above the others when rates are the same. The problem is that this is obvious to everyone, and we may look bad if we do it too overtly.

Better to use a “magical” regex and obfuscate our master plan.