### PR TITLE
fix(styles): earnings card background in dark mode

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1904,7 +1904,7 @@ body {
   min-width: 200px;
   max-width: 240px;
   flex-shrink: 0;
-  background: #fff;
+  background: var(--card-bg);
   border: 1px solid var(--border-light);
   border-radius: 10px;
   padding: 12px;


### PR DESCRIPTION
## Summary
- `.earnings-day-card` tenía `background: #fff` hardcodeado, rompiendo el look en dark mode
- Reemplazado por `var(--card-bg)` para que respete el theme

## Test plan
- [x] Verificado en preview local con `data-theme="dark"` → fondo `rgb(45,45,50)` (antes `rgb(255,255,255)`)
- [ ] Verificar en rendimientos.co post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)