### PR TITLE
feat(cedears): sorting por columnas + descarga CSV

### DIFF
--- a/public/cedears/cedears.css
+++ b/public/cedears/cedears.css
@@ -44,9 +44,9 @@
 .cedears-toolbar {
   display: flex;
   align-items: center;
-  justify-content: space-between;
   gap: 10px;
   margin-bottom: 12px;
+  flex-wrap: wrap;
 }
 
 .cedears-view-toggle {
@@ -79,7 +79,8 @@
 
 .cedears-search-wrap {
   flex: 1;
-  max-width: 340px;
+  min-width: 220px;
+  max-width: 360px;
 }
 
 .cedears-search {
@@ -98,6 +99,35 @@
 .cedears-search:focus {
   border-color: var(--accent);
   box-shadow: 0 0 0 2px color-mix(in srgb, var(--accent) 18%, transparent);
+}
+
+.cedears-actions {
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.cedears-download-btn {
+  border: 1px solid var(--border);
+  background: var(--card-bg);
+  color: var(--text-secondary);
+  border-radius: 10px;
+  height: 34px;
+  padding: 0 12px;
+  font-size: 0.76rem;
+  font-weight: 700;
+  font-family: var(--font);
+  cursor: pointer;
+}
+
+.cedears-download-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent-dark);
+  background: var(--accent-light);
+}
+
+.cedears-download-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
 }
 
 .cedears-loading {
@@ -149,6 +179,40 @@
 
 .cedears-table .col-right {
   text-align: right;
+}
+
+.cedears-sort-header {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  color: inherit;
+  font: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+
+.cedears-sort-header.col-right {
+  margin-left: auto;
+}
+
+.cedears-sort-header:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--accent) 55%, transparent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
+.cedears-sort-header[data-active='true'] {
+  color: var(--accent-dark);
+}
+
+.sort-indicator {
+  display: inline-block;
+  width: 10px;
+  color: var(--accent);
 }
 
 .cedear-row td {
@@ -278,6 +342,14 @@
 
   .cedears-search-wrap {
     max-width: none;
+  }
+
+  .cedears-actions {
+    margin-left: 0;
+  }
+
+  .cedears-download-btn {
+    width: 100%;
   }
 
   .cedears-chart-inner {

--- a/public/cedears/cedears.js
+++ b/public/cedears/cedears.js
@@ -2,10 +2,22 @@ let cedearsItems = [];
 let currentFilteredItems = [];
 let currentView = 'table';
 let cedearsScatterChart = null;
+let currentSortKey = 'ticker';
+let currentSortDir = 'asc';
+const SORTABLE_NUMERIC_FIELDS = new Set([
+  'priceArs',
+  'priceD',
+  'priceC',
+  'priceUnderlying',
+  'impliedMep',
+  'impliedCable',
+]);
 
 document.addEventListener('DOMContentLoaded', () => {
   setupThemeToggle();
   setupViewToggle();
+  setupHeaderSorting();
+  setupCsvDownload();
   loadCedears();
 });
 
@@ -27,6 +39,55 @@ function setupViewToggle() {
     btn.addEventListener('click', () => {
       setView(btn.dataset.view || 'table');
     });
+  });
+}
+
+function setupHeaderSorting() {
+  const buttons = document.querySelectorAll('.cedears-sort-header');
+  buttons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const key = button.dataset.sortKey || 'ticker';
+      if (key === currentSortKey) {
+        currentSortDir = currentSortDir === 'asc' ? 'desc' : 'asc';
+      } else {
+        currentSortKey = key;
+        currentSortDir = 'asc';
+      }
+      updateHeaderSortUI();
+      renderFilteredList(getSearchTerm());
+    });
+  });
+
+  updateHeaderSortUI();
+}
+
+function updateHeaderSortUI() {
+  const buttons = document.querySelectorAll('.cedears-sort-header');
+  buttons.forEach((button) => {
+    const key = button.dataset.sortKey || '';
+    const isActive = key === currentSortKey;
+    const parentTh = button.closest('th');
+    const indicator = button.querySelector('.sort-indicator');
+
+    button.dataset.active = isActive ? 'true' : 'false';
+    button.dataset.dir = isActive ? currentSortDir : '';
+
+    if (parentTh) {
+      parentTh.setAttribute('aria-sort', isActive ? (currentSortDir === 'asc' ? 'ascending' : 'descending') : 'none');
+    }
+    if (indicator) {
+      indicator.textContent = isActive ? (currentSortDir === 'asc' ? '▲' : '▼') : '';
+    }
+  });
+}
+
+function setupCsvDownload() {
+  const downloadButton = document.getElementById('cedears-download-csv');
+  if (!downloadButton) return;
+
+  downloadButton.disabled = true;
+  downloadButton.addEventListener('click', () => {
+    downloadCurrentCsv();
   });
 }
 
@@ -93,6 +154,7 @@ async function loadCedears() {
     }
 
     if (loading) loading.hidden = true;
+    updateCsvButtonState();
     setView('table');
   } catch (error) {
     console.error('CEDEARs load error:', error);
@@ -101,6 +163,7 @@ async function loadCedears() {
       errorBox.hidden = false;
       errorBox.textContent = 'No se pudo cargar la lista de CEDEARs en este momento.';
     }
+    updateCsvButtonState();
   }
 }
 
@@ -153,14 +216,142 @@ function renderFilteredList(query) {
       item.ticker.toUpperCase().includes(term) ||
       String(item.name || '').toUpperCase().includes(term))
     : cedearsItems;
+  const sorted = sortCedears(filtered);
 
-  currentFilteredItems = filtered;
-  renderTable(filtered);
-  renderImplicitAverages(filtered);
+  currentFilteredItems = sorted;
+  renderTable(sorted);
+  renderImplicitAverages(sorted);
+  updateCsvButtonState();
 
   if (currentView === 'chart') {
-    renderScatterChart(filtered);
+    renderScatterChart(sorted);
   }
+}
+
+function sortCedears(items) {
+  const list = Array.isArray(items) ? items.slice() : [];
+  const dir = currentSortDir === 'desc' ? -1 : 1;
+
+  return list.sort((a, b) => {
+    if (currentSortKey === 'ticker') {
+      return dir * String(a.ticker || '').localeCompare(String(b.ticker || ''), 'en-US');
+    }
+
+    if (currentSortKey === 'ratio') {
+      const ratioCompare = compareNullableNumbers(parseRatioForSort(a.ratio), parseRatioForSort(b.ratio), dir);
+      if (ratioCompare !== 0) return ratioCompare;
+      return dir * String(a.ratio || '').localeCompare(String(b.ratio || ''), 'en-US');
+    }
+
+    if (SORTABLE_NUMERIC_FIELDS.has(currentSortKey)) {
+      const compare = compareNullableNumbers(a[currentSortKey], b[currentSortKey], dir);
+      if (compare !== 0) return compare;
+      return String(a.ticker || '').localeCompare(String(b.ticker || ''), 'en-US');
+    }
+
+    return dir * String(a.ticker || '').localeCompare(String(b.ticker || ''), 'en-US');
+  });
+}
+
+function compareNullableNumbers(aValue, bValue, dir) {
+  const aValid = typeof aValue === 'number' && Number.isFinite(aValue);
+  const bValid = typeof bValue === 'number' && Number.isFinite(bValue);
+
+  if (!aValid && !bValid) return 0;
+  if (!aValid) return 1;
+  if (!bValid) return -1;
+  if (aValue === bValue) return 0;
+
+  return aValue < bValue ? -1 * dir : 1 * dir;
+}
+
+function parseRatioForSort(ratio) {
+  if (ratio === null || ratio === undefined) return null;
+
+  const raw = String(ratio).trim();
+  if (!raw) return null;
+  if (raw.includes(':')) {
+    const [left, right] = raw.split(':');
+    const leftNum = Number(left);
+    const rightNum = Number(right);
+    if (Number.isFinite(leftNum) && Number.isFinite(rightNum) && rightNum !== 0) {
+      return leftNum / rightNum;
+    }
+  }
+
+  const numeric = Number(raw.replace(',', '.'));
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function getSearchTerm() {
+  const searchInput = document.getElementById('cedears-search');
+  return searchInput ? (searchInput.value || '') : '';
+}
+
+function updateCsvButtonState() {
+  const downloadButton = document.getElementById('cedears-download-csv');
+  if (!downloadButton) return;
+  downloadButton.disabled = !currentFilteredItems.length;
+}
+
+function downloadCurrentCsv() {
+  if (!currentFilteredItems.length) return;
+
+  const headers = [
+    'ticker',
+    'name',
+    'ratio',
+    'price_ars',
+    'price_d',
+    'price_c',
+    'price_usa',
+    'implied_mep_ars',
+    'implied_cable_ars',
+    'ticker_d',
+    'ticker_c',
+    'ticker_usa',
+  ];
+
+  const rows = currentFilteredItems.map((item) => ([
+    item.ticker,
+    item.name,
+    item.ratio,
+    formatCsvNumber(item.priceArs),
+    formatCsvNumber(item.priceD),
+    formatCsvNumber(item.priceC),
+    formatCsvNumber(item.priceUnderlying),
+    formatCsvNumber(item.impliedMep),
+    formatCsvNumber(item.impliedCable),
+    item.tickerD,
+    item.tickerC,
+    item.tickerUsa,
+  ]));
+
+  const csvContent = [headers, ...rows]
+    .map(row => row.map(escapeCsvValue).join(','))
+    .join('\n');
+
+  const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  const datePart = new Date().toISOString().slice(0, 10);
+  link.href = url;
+  link.download = `cedears-${datePart}.csv`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}
+
+function formatCsvNumber(value) {
+  if (!Number.isFinite(value)) return '';
+  return String(Math.round(value * 1000000) / 1000000);
+}
+
+function escapeCsvValue(value) {
+  const raw = value === null || value === undefined ? '' : String(value);
+  const escaped = raw.replace(/"/g, '""');
+  return `"${escaped}"`;
 }
 
 function renderTable(items) {

--- a/public/cedears/index.html
+++ b/public/cedears/index.html
@@ -111,6 +111,9 @@
         <div class="cedears-search-wrap">
           <input id="cedears-search" class="cedears-search" type="search" placeholder="Buscar ticker o nombre" autocomplete="off" />
         </div>
+        <div class="cedears-actions">
+          <button type="button" id="cedears-download-csv" class="cedears-download-btn">Descargar CSV</button>
+        </div>
       </div>
 
       <div class="loading cedears-loading" id="cedears-loading">
@@ -124,14 +127,14 @@
         <table class="cedears-table">
           <thead>
             <tr>
-              <th>Activo</th>
-              <th class="col-right">Precio ARS</th>
-              <th class="col-right">Precio D</th>
-              <th class="col-right">Precio C</th>
-              <th class="col-right">Precio EE.UU</th>
-              <th class="col-right">MEP Implícito</th>
-              <th class="col-right">Cable Implícito</th>
-              <th class="col-right">Ratio</th>
+              <th scope="col"><button type="button" class="cedears-sort-header" data-sort-key="ticker">Activo <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="priceArs">Precio ARS <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="priceD">Precio D <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="priceC">Precio C <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="priceUnderlying">Precio EE.UU <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="impliedMep">MEP Implícito <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="impliedCable">Cable Implícito <span class="sort-indicator" aria-hidden="true"></span></button></th>
+              <th scope="col" class="col-right"><button type="button" class="cedears-sort-header col-right" data-sort-key="ratio">Ratio <span class="sort-indicator" aria-hidden="true"></span></button></th>
             </tr>
           </thead>
           <tbody id="cedears-list"></tbody>


### PR DESCRIPTION
## Resumen
- mueve el sorting de CEDEARs a los headers de la tabla (click en columna + toggle asc/desc)
- mantiene el ordenamiento sobre estado (`currentFilteredItems`) para que tabla, gráfico y exportación queden siempre consistentes
- agrega botón `Descargar CSV` con export del subconjunto visible (filtrado + ordenado), con escaping seguro y nulos en blanco
- suma estilos para headers ordenables, indicador visual de dirección y estado disabled del botón CSV

## Plan de prueba
- [x] validar que cada header ordenable cambie el orden de filas
- [x] validar toggle asc/desc al volver a clickear la misma columna
- [x] validar combinación búsqueda + sorting
- [x] validar que el botón CSV se deshabilite cuando no hay resultados
- [x] validar que alternar tabla/gráfico siga funcionando
- [x] verificar que no haya errores de consola en `/cedears`


<img width="1932" height="1292" alt="CleanShot 2026-04-17 at 13 39 12@2x" src="https://github.com/user-attachments/assets/b5485845-2a83-4a43-a200-379e96a592d4" />
