### PR TITLE
feat(earnings): add calendar page and improve home navigation

### DIFF
--- a/public/cedears/index.html
+++ b/public/cedears/index.html
@@ -41,6 +41,9 @@
         <a href="/#mundo" class="currency-tab">
           <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></span> Mundo
         </a>
+        <a href="/earnings" class="currency-tab">
+          <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span> Earnings
+        </a>
         <a href="/cedears" class="currency-tab active" aria-current="page">
           <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg></span> CEDEARs
         </a>

--- a/public/earnings/earnings.css
+++ b/public/earnings/earnings.css
@@ -1,0 +1,515 @@
+.earnings-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 14px;
+}
+
+/* Selector de período - alineado a la izquierda */
+.earnings-nav {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  gap: 8px;
+  flex: 0 0 auto;
+}
+
+#earnings-period-label {
+  min-width: 140px;
+  text-align: center;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+  letter-spacing: var(--tracking-body);
+}
+
+/* Iconos de vista (semanal/mensual) - a la derecha */
+.earnings-view-icons {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius-sm);
+  background: var(--card-bg);
+  padding: 3px;
+  flex-shrink: 0;
+}
+
+.earnings-view-icon {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 32px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  color: var(--text-secondary);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: all 0.15s ease;
+  font-family: var(--font);
+  font-size: 0.72rem;
+  font-weight: 500;
+}
+
+.earnings-view-icon:hover {
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.earnings-view-icon.active {
+  background: var(--accent-light);
+  color: var(--accent);
+}
+
+.earnings-view-icon svg {
+  display: block;
+  flex-shrink: 0;
+}
+
+.earnings-view-label {
+  white-space: nowrap;
+}
+
+.earnings-nav-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: 1px solid var(--border-light);
+  border-radius: 6px;
+  background: var(--card-bg);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s ease;
+}
+
+.earnings-nav-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.earnings-nav-btn:not(:disabled):hover {
+  border-color: var(--accent);
+  background: var(--bg-subtle);
+  color: var(--text);
+}
+
+.earnings-nav-btn svg {
+  display: block;
+}
+
+/* Loading y Error */
+.earnings-loading {
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-sm);
+}
+
+.earnings-error {
+  padding: 18px 20px;
+  border: 1px solid var(--border-light);
+  border-radius: var(--radius);
+  background: var(--red-bg);
+  color: var(--red);
+  font-weight: 600;
+}
+
+/* Earnings Timeline - Estilos de arisbdar */
+.earnings-timeline {
+  display: flex;
+  gap: 10px;
+  overflow-x: auto;
+  padding-bottom: 4px;
+}
+
+.earnings-day-card {
+  min-width: 200px;
+  max-width: 240px;
+  flex-shrink: 0;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  padding: 12px;
+  transition: border-color 0.15s, box-shadow 0.15s;
+}
+
+.earnings-day-card:hover {
+  border-color: var(--accent);
+  box-shadow: var(--shadow);
+}
+
+.earnings-logo-wrap {
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  overflow: hidden;
+  flex-shrink: 0;
+  background: var(--border-light);
+}
+
+.earnings-logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+.earnings-logo-fallback {
+  width: 100%;
+  height: 100%;
+  border-radius: 6px;
+  background: var(--border-light);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.5rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-align: center;
+  padding: 2px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.earnings-empty-day {
+  font-size: 0.7rem;
+  color: var(--text-tertiary);
+}
+
+/* Grilla de logos */
+.earnings-logo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(44px, 1fr));
+  gap: 8px;
+}
+
+.earnings-logo-item {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  cursor: help;
+}
+
+.earnings-logo-item:hover::after {
+  content: attr(data-tooltip);
+  position: absolute;
+  bottom: calc(100% + 8px);
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--text);
+  color: var(--card-bg);
+  border-radius: 6px;
+  padding: 6px 8px;
+  font-size: 0.62rem;
+  font-weight: 500;
+  line-height: 1.3;
+  text-align: center;
+  white-space: normal;
+  min-width: 140px;
+  max-width: 220px;
+  z-index: 20;
+  pointer-events: none;
+  box-shadow: var(--shadow);
+}
+
+.earnings-logo-item:hover::before {
+  content: '';
+  position: absolute;
+  bottom: calc(100% + 3px);
+  left: 50%;
+  transform: translateX(-50%);
+  border-width: 5px;
+  border-style: solid;
+  border-color: var(--text) transparent transparent transparent;
+  z-index: 20;
+  pointer-events: none;
+}
+
+/* Grilla compacta para vista mensual */
+.month-day-events .earnings-logo-grid {
+  grid-template-columns: repeat(4, 1fr);
+  gap: 4px;
+}
+
+.month-day-events .earnings-logo-item {
+  width: 100%;
+}
+
+@media (max-width: 1200px) {
+  .month-day-events .earnings-logo-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+/* Secciones Before/After */
+.earnings-day-content {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.earnings-section {
+  border-top: 1px solid var(--border-light);
+  padding-top: 10px;
+}
+
+.earnings-section:first-child {
+  border-top: none;
+  padding-top: 0;
+}
+
+.earnings-section-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.68rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+  margin-bottom: 8px;
+  letter-spacing: 0.02em;
+}
+
+.earnings-section-header svg {
+  flex-shrink: 0;
+  opacity: 0.8;
+}
+
+/* Badge IPO */
+.ipo-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  background: var(--green);
+  color: #FFF;
+  border-radius: 999px;
+  flex-shrink: 0;
+}
+
+.ipo-badge-small {
+  padding: 1px 5px;
+  font-size: 0.58rem;
+}
+
+/* Header de card con IPO */
+.earnings-day-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.earnings-day-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.earnings-day-title span {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--accent);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+.earnings-day-title strong {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* Vista Semanal Grid - 5 días hábiles en una línea */
+.earnings-week-grid {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 10px;
+}
+
+.earnings-week-grid .earnings-day-card {
+  min-width: auto;
+  max-width: none;
+}
+
+@media (max-width: 1024px) {
+  .earnings-week-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 768px) {
+  .earnings-week-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+@media (max-width: 480px) {
+  .earnings-week-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* Vista Mensual - 5 días hábiles */
+.month-weekday-row {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+  margin-bottom: 6px;
+}
+
+.month-weekday-row span {
+  font-size: 0.65rem;
+  color: var(--text-tertiary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  text-align: center;
+}
+
+.earnings-month-grid {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  gap: 6px;
+}
+
+.month-day-cell {
+  min-height: 112px;
+  background: var(--card-bg);
+  border: 1px solid var(--border-light);
+  border-radius: 10px;
+  box-shadow: var(--shadow-sm);
+  padding: 8px;
+}
+
+.month-day-cell.muted {
+  opacity: 0.72;
+}
+
+.month-day-cell.out-of-range {
+  background: var(--bg-subtle);
+}
+
+.month-day-cell header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.month-day-cell header span:first-child {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+  font-weight: 600;
+}
+
+.month-day-count {
+  font-size: 0.63rem;
+  font-weight: 700;
+  border-radius: 999px;
+  background: var(--accent-light);
+  color: var(--accent);
+  padding: 2px 6px;
+}
+
+.month-day-events {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.month-section {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.month-section-header {
+  font-size: 0.6rem;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  line-height: 1;
+  display: inline-flex;
+  align-items: center;
+}
+
+.month-event-item {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.66rem;
+  color: var(--text-secondary);
+}
+
+.month-event-item .earnings-logo-wrap {
+  width: 18px;
+  height: 18px;
+  border-radius: 5px;
+}
+
+.month-more {
+  font-size: 0.62rem;
+  color: var(--text-tertiary);
+}
+
+/* Responsive */
+@media (max-width: 640px) {
+  .earnings-toolbar {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 10px;
+  }
+
+  .earnings-nav {
+    order: 2;
+    justify-content: center;
+  }
+
+  .earnings-view-icons {
+    order: 1;
+    align-self: center;
+  }
+
+  #earnings-period-label {
+    min-width: 120px;
+    font-size: 0.72rem;
+  }
+
+.earnings-week-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .earnings-logo-grid {
+    grid-template-columns: repeat(auto-fill, minmax(36px, 1fr));
+    gap: 6px;
+  }
+
+  .earnings-month-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .month-day-cell {
+    min-height: 90px;
+    padding: 6px;
+  }
+
+  .month-weekday-row {
+    display: none;
+  }
+
+  .earnings-section-header {
+    font-size: 0.62rem;
+  }
+
+  .ipo-badge {
+    padding: 1px 5px;
+    font-size: 0.58rem;
+  }
+}

--- a/public/earnings/earnings.js
+++ b/public/earnings/earnings.js
@@ -1,0 +1,429 @@
+const state = {
+  view: 'week',
+  today: startOfDay(new Date()),
+  endDate: null,
+  allEvents: {},
+  weekStarts: [],
+  monthStarts: [],
+  weekIndex: 0,
+  monthIndex: 0,
+};
+
+const DAY_NAMES = ['Dom', 'Lun', 'Mar', 'Mié', 'Jue', 'Vie', 'Sáb'];
+const MONTH_NAMES = ['Enero', 'Febrero', 'Marzo', 'Abril', 'Mayo', 'Junio', 'Julio', 'Agosto', 'Septiembre', 'Octubre', 'Noviembre', 'Diciembre'];
+
+document.addEventListener('DOMContentLoaded', () => {
+  setupThemeToggle();
+  setupViewToggle();
+  setupNavigation();
+  loadEarningsCalendar();
+});
+
+function setupThemeToggle() {
+  const btn = document.getElementById('theme-toggle');
+  if (!btn) return;
+  btn.addEventListener('click', () => {
+    const current = document.documentElement.getAttribute('data-theme');
+    const next = current === 'dark' ? 'light' : 'dark';
+    document.documentElement.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+  });
+}
+
+function setupViewToggle() {
+  document.querySelectorAll('.earnings-view-icon').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      const nextView = btn.dataset.view === 'month' ? 'month' : 'week';
+      state.view = nextView;
+      document.querySelectorAll('.earnings-view-icon').forEach((b) => {
+        const active = b.dataset.view === nextView;
+        b.classList.toggle('active', active);
+        b.setAttribute('aria-selected', active ? 'true' : 'false');
+      });
+      renderCurrentView();
+    });
+  });
+}
+
+function setupNavigation() {
+  const prev = document.getElementById('earnings-prev');
+  const next = document.getElementById('earnings-next');
+  if (prev) prev.addEventListener('click', () => shiftPeriod(-1));
+  if (next) next.addEventListener('click', () => shiftPeriod(1));
+}
+
+async function loadEarningsCalendar() {
+  const loading = document.getElementById('earnings-loading');
+  const errorBox = document.getElementById('earnings-error');
+  const calendar = document.getElementById('earnings-calendar');
+  const source = document.getElementById('earnings-source');
+
+  try {
+    const today = startOfDay(new Date());
+    // Para la vista mensual completa, pedimos desde el primer día del mes actual
+    const startOfCurrentMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    const end = addMonths(startOfCurrentMonth, 3);
+    state.today = today;
+    state.startDate = startOfCurrentMonth;
+    state.endDate = end;
+
+    const res = await fetch(`/api/earnings?start=${toIsoDate(startOfCurrentMonth)}&end=${toIsoDate(end)}`);
+    if (!res.ok) throw new Error(`API error: ${res.status}`);
+    const data = await res.json();
+
+    state.allEvents = normalizeEarnings(data, startOfCurrentMonth, end);
+    state.weekStarts = buildWeekStarts(today, end);
+    state.monthStarts = buildMonthStarts(startOfCurrentMonth, end);
+    state.weekIndex = 0;
+    state.monthIndex = 0;
+
+    if (loading) loading.hidden = true;
+    if (errorBox) errorBox.hidden = true;
+    if (calendar) calendar.hidden = false;
+    if (source) {
+      source.textContent = `Rango: ${formatDateLong(startOfCurrentMonth)} - ${formatDateLong(end)} | Actualizado ${new Date().toLocaleTimeString('es-AR', { hour: '2-digit', minute: '2-digit' })}`;
+    }
+    renderCurrentView();
+  } catch (err) {
+    console.error('Earnings calendar error:', err);
+    if (loading) loading.hidden = true;
+    if (errorBox) {
+      errorBox.hidden = false;
+      errorBox.textContent = 'No se pudo cargar el earnings calendar en este momento.';
+    }
+  }
+}
+
+function normalizeEarnings(payload, start, end) {
+  const parsed = {};
+  const startKey = toIsoDate(start);
+  const endKey = toIsoDate(end);
+  const days = Object.keys(payload || {}).sort();
+  for (const day of days) {
+    if (day < startKey || day > endKey) continue;
+    const items = (payload[day] || [])
+      .filter((e) => e && e.isDateConfirmed && Number(e.marketCap) > 0 && e.symbol)
+      .sort((a, b) => Number(b.marketCap || 0) - Number(a.marketCap || 0))
+      .slice(0, 12);
+    if (items.length) parsed[day] = items;
+  }
+  return parsed;
+}
+
+function buildWeekStarts(start, end) {
+  const starts = [];
+  const first = startOfWeek(start, 1);
+  let cursor = first;
+  while (cursor <= end) {
+    starts.push(cursor);
+    cursor = addDays(cursor, 7);
+  }
+  return starts;
+}
+
+function buildMonthStarts(start, end) {
+  const starts = [];
+  let cursor = new Date(start.getFullYear(), start.getMonth(), 1);
+  while (cursor <= end) {
+    starts.push(cursor);
+    cursor = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1);
+  }
+  return starts;
+}
+
+function shiftPeriod(step) {
+  if (state.view === 'week') {
+    const next = clamp(state.weekIndex + step, 0, state.weekStarts.length - 1);
+    state.weekIndex = next;
+  } else {
+    const next = clamp(state.monthIndex + step, 0, state.monthStarts.length - 1);
+    state.monthIndex = next;
+  }
+  renderCurrentView();
+}
+
+function renderCurrentView() {
+  if (state.view === 'week') {
+    renderWeekView();
+  } else {
+    renderMonthView();
+  }
+  syncNavState();
+}
+
+function renderWeekView() {
+  const root = document.getElementById('earnings-calendar');
+  if (!root) return;
+  const weekStart = state.weekStarts[state.weekIndex];
+  const weekEnd = addDays(weekStart, 4); // Viernes (Lun + 4 días)
+  const days = [];
+  for (let i = 0; i < 5; i++) { // Solo 5 días hábiles (Lun-Vie)
+    const current = addDays(weekStart, i);
+    if (current < state.today || current > state.endDate) continue;
+    const key = toIsoDate(current);
+    days.push({
+      date: current,
+      key,
+      items: state.allEvents[key] || [],
+    });
+  }
+
+  const dayCards = days.map((day) => {
+    const beforeOpen = day.items.filter(item => isBeforeOpen(item.earningsTime));
+    const afterClose = day.items.filter(item => isAfterClose(item.earningsTime));
+    const during = day.items.filter(item => !isBeforeOpen(item.earningsTime) && !isAfterClose(item.earningsTime));
+    const hasIpo = hasIPO(day.items);
+    
+    // All items are shown in grids - Before, After, and During
+    const hasContent = beforeOpen.length > 0 || afterClose.length > 0 || during.length > 0;
+    
+    return `
+    <article class="earnings-day-card">
+      <div class="earnings-day-header">
+        <div class="earnings-day-title">
+          <span>${DAY_NAMES[day.date.getDay()]}</span>
+          <strong>${day.date.getDate()} ${MONTH_NAMES[day.date.getMonth()].slice(0, 3)}</strong>
+        </div>
+        ${hasIpo ? '<span class="ipo-badge">IPO</span>' : ''}
+      </div>
+      ${hasContent ? `
+        <div class="earnings-day-content">
+          ${beforeOpen.length ? renderEarningsSection(beforeOpen, 'before') : ''}
+          ${afterClose.length ? renderEarningsSection(afterClose, 'after') : ''}
+          ${during.length ? renderLogoGrid(during, 40) : ''}
+        </div>
+      ` : '<p class="earnings-empty-day">Sin reportes confirmados</p>'}
+    </article>
+  `;
+  }).join('');
+
+  root.innerHTML = `
+    <div class="earnings-week-grid">
+      ${dayCards}
+    </div>
+  `;
+
+  setPeriodLabel(`${formatDateShort(weekStart)} - ${formatDateShort(weekEnd)}`);
+}
+
+function renderMonthView() {
+  const root = document.getElementById('earnings-calendar');
+  if (!root) return;
+  const monthStart = state.monthStarts[state.monthIndex];
+  const monthEnd = new Date(monthStart.getFullYear(), monthStart.getMonth() + 1, 0);
+  const gridStart = startOfWeek(monthStart, 1);
+  const gridEnd = addDays(startOfWeek(monthEnd, 1), 6);
+  const cells = [];
+  let cursor = gridStart;
+
+  while (cursor <= gridEnd) {
+    const dayOfWeek = cursor.getDay();
+    // Saltear sábados (6) y domingos (0)
+    if (dayOfWeek !== 0 && dayOfWeek !== 6) {
+      const key = toIsoDate(cursor);
+      const inMonth = cursor.getMonth() === monthStart.getMonth();
+      const inRange = cursor >= state.startDate && cursor <= state.endDate;
+      const events = inRange ? (state.allEvents[key] || []) : [];
+      const beforeOpen = events.filter(item => isBeforeOpen(item.earningsTime));
+      const afterClose = events.filter(item => isAfterClose(item.earningsTime));
+      const during = events.filter(item => !isBeforeOpen(item.earningsTime) && !isAfterClose(item.earningsTime));
+      const hasIpo = hasIPO(events);
+      const hasEvents = events.length > 0;
+
+      const renderMonthSection = (items, type) => {
+        if (!items.length) return '';
+        const icon = type === 'before'
+          ? '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
+          : '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+        return `
+          <div class="month-section ${type}">
+            <div class="month-section-header">${icon}</div>
+            ${renderLogoGrid(items, 24)}
+          </div>
+        `;
+      };
+
+      cells.push(`
+        <article class="month-day-cell${inMonth ? '' : ' muted'}${inRange ? '' : ' out-of-range'}">
+          <header>
+            <span>${cursor.getDate()}</span>
+            ${hasIpo ? '<span class="ipo-badge ipo-badge-small">IPO</span>' : ''}
+          </header>
+          ${hasEvents ? `
+            <div class="month-day-events">
+              ${renderMonthSection(beforeOpen, 'before')}
+              ${renderMonthSection(afterClose, 'after')}
+              ${during.length ? renderLogoGrid(during, 24) : ''}
+            </div>
+          ` : ''}
+        </article>
+      `);
+    }
+
+    cursor = addDays(cursor, 1);
+  }
+
+  root.innerHTML = `
+    <div class="month-weekday-row">
+      ${['Lun', 'Mar', 'Mié', 'Jue', 'Vie'].map((d) => `<span>${d}</span>`).join('')}
+    </div>
+    <div class="earnings-month-grid">
+      ${cells.join('')}
+    </div>
+  `;
+
+  setPeriodLabel(`${MONTH_NAMES[monthStart.getMonth()]} ${monthStart.getFullYear()}`);
+}
+
+function syncNavState() {
+  const prev = document.getElementById('earnings-prev');
+  const next = document.getElementById('earnings-next');
+  if (!prev || !next) return;
+
+  if (state.view === 'week') {
+    prev.disabled = state.weekIndex <= 0;
+    next.disabled = state.weekIndex >= state.weekStarts.length - 1;
+  } else {
+    prev.disabled = state.monthIndex <= 0;
+    next.disabled = state.monthIndex >= state.monthStarts.length - 1;
+  }
+}
+
+function setPeriodLabel(text) {
+  const label = document.getElementById('earnings-period-label');
+  if (label) label.textContent = text;
+}
+
+function formatMarketCap(value) {
+  if (!value) return '';
+  const num = Number(value);
+  if (num >= 1e12) return '$' + (num / 1e12).toFixed(2) + 'T';
+  if (num >= 1e9) return '$' + (num / 1e9).toFixed(2) + 'B';
+  if (num >= 1e6) return '$' + (num / 1e6).toFixed(2) + 'M';
+  return '$' + num.toLocaleString();
+}
+
+function logoHtml(symbol, size = 24) {
+  const safeSymbol = encodeURIComponent(symbol);
+  const style = size !== 24 ? ` style="width:${size}px;height:${size}px;border-radius:${size > 30 ? 8 : 6}px;"` : '';
+  
+  return `
+    <span class="earnings-logo-wrap"${style}>
+      <img class="earnings-logo" src="https://static.svvytrdr.com/logos/${safeSymbol}.webp" alt="${escapeHtml(symbol)}" onerror="this.style.display='none';this.nextElementSibling.style.display='flex'">
+      <span class="earnings-logo-fallback" style="display:none">${escapeHtml(symbol)}</span>
+    </span>
+  `;
+}
+
+function earningsTimeLabel(time) {
+  if (!time) return '';
+  const hour = parseInt(String(time).split(':')[0], 10);
+  if (hour < 9) return 'Before Open';
+  if (hour >= 16) return 'After Close';
+  return 'During';
+}
+
+function isBeforeOpen(time) {
+  if (!time) return false;
+  const hour = parseInt(String(time).split(':')[0], 10);
+  return hour < 9;
+}
+
+function isAfterClose(time) {
+  if (!time) return false;
+  const hour = parseInt(String(time).split(':')[0], 10);
+  return hour >= 16;
+}
+
+function hasIPO(items) {
+  return items.some(item => item.ipo === true || item.isIPO === true);
+}
+
+function renderLogoGrid(items, size = 40) {
+  if (!items || items.length === 0) return '';
+  return `
+    <div class="earnings-logo-grid" style="--logo-size: ${size}px;">
+      ${items.map(item => {
+        const tooltipParts = [item.symbol];
+        const companyName = item.name || item.companyName;
+        if (companyName) tooltipParts.push(companyName);
+        if (item.marketCap) tooltipParts.push(formatMarketCap(item.marketCap));
+        const tooltip = tooltipParts.join(' | ');
+        return `
+          <div class="earnings-logo-item" title="${escapeHtml(tooltip)}" data-tooltip="${escapeHtml(tooltip)}" aria-label="${escapeHtml(tooltip)}">
+            ${logoHtml(item.symbol, size)}
+          </div>
+        `;
+      }).join('')}
+    </div>
+  `;
+}
+
+function renderEarningsSection(items, sectionType) {
+  if (!items || items.length === 0) return '';
+  
+  const icon = sectionType === 'before'
+    ? '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><line x1="12" y1="2" x2="12" y2="4"/><line x1="12" y1="20" x2="12" y2="22"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="2" y1="12" x2="4" y2="12"/><line x1="20" y1="12" x2="22" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>'
+    : '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+  
+  const label = sectionType === 'before' ? 'Before Open' : 'After Close';
+  
+  return `
+    <div class="earnings-section ${sectionType}">
+      <div class="earnings-section-header">
+        ${icon}
+        <span>${label}</span>
+      </div>
+      ${renderLogoGrid(items, 40)}
+    </div>
+  `;
+}
+
+function addDays(date, days) {
+  const copy = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+  copy.setDate(copy.getDate() + days);
+  return copy;
+}
+
+function addMonths(date, months) {
+  return new Date(date.getFullYear(), date.getMonth() + months, date.getDate());
+}
+
+function startOfDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+function startOfWeek(date, weekStartsOn) {
+  const copy = startOfDay(date);
+  const day = copy.getDay();
+  const diff = (day - weekStartsOn + 7) % 7;
+  return addDays(copy, -diff);
+}
+
+function toIsoDate(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+function formatDateShort(date) {
+  return `${date.getDate()} ${MONTH_NAMES[date.getMonth()].slice(0, 3)}`;
+}
+
+function formatDateLong(date) {
+  return `${date.getDate()} ${MONTH_NAMES[date.getMonth()]} ${date.getFullYear()}`;
+}
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/public/earnings/index.html
+++ b/public/earnings/index.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Earnings Calendar | Rendimientos AR</title>
+  <meta name="description" content="Calendario de earnings para los próximos 3 meses con vistas semanales y mensuales.">
+
+  <meta property="og:type" content="website">
+  <meta property="og:url" content="https://rendimientos.co/earnings">
+  <meta property="og:title" content="Earnings Calendar | Rendimientos AR">
+  <meta property="og:description" content="Seguí próximos reportes de resultados con vistas semanales y mensuales.">
+  <meta property="og:image" content="https://rendimientos.co/og-image.png">
+  <meta property="og:site_name" content="Rendimientos AR">
+  <meta property="og:locale" content="es_AR">
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="Earnings Calendar | Rendimientos AR">
+  <meta name="twitter:description" content="Próximos earnings para los próximos 3 meses en una sola vista.">
+  <meta name="twitter:image" content="https://rendimientos.co/og-image.png">
+
+  <link rel="canonical" href="https://rendimientos.co/earnings">
+  <link rel="icon" href="/icons/icon-192.png" type="image/png">
+  <meta name="theme-color" content="#f0f4f9">
+  <script>!function(){var t=localStorage.getItem('theme')||(matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light');document.documentElement.setAttribute('data-theme',t)}()</script>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Instrument+Serif:ital@0;1&family=Inter+Tight:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Newsreader:ital,wght@0,400;1,400&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/styles.css">
+  <link rel="stylesheet" href="/earnings/earnings.css">
+</head>
+<body>
+  <header class="header">
+    <div class="header-inner">
+      <div class="header-left">
+        <a href="/" class="logo" aria-label="Ir a la página principal"><svg class="icon-logo" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg> RENDIMIENTOS.CO</a>
+      </div>
+      <nav class="currency-tabs" aria-label="Secciones">
+        <a href="/#mundo" class="currency-tab">
+          <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><line x1="2" y1="12" x2="22" y2="12"/><path d="M12 2a15.3 15.3 0 0 1 4 10 15.3 15.3 0 0 1-4 10 15.3 15.3 0 0 1-4-10 15.3 15.3 0 0 1 4-10z"/></svg></span> Mundo
+        </a>
+        <a href="/earnings" class="currency-tab active" aria-current="page">
+          <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg></span> Earnings
+        </a>
+        <a href="/cedears" class="currency-tab">
+          <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 7 13.5 15.5 8.5 10.5 2 17"/><polyline points="16 7 22 7 22 13"/></svg></span> CEDEARs
+        </a>
+        <a href="/#ars" class="currency-tab">
+          <span class="flag"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="1" x2="12" y2="23"/><path d="M17 5H9.5a3.5 3.5 0 0 0 0 7h5a3.5 3.5 0 0 1 0 7H6"/></svg></span> ARS
+        </a>
+      </nav>
+      <div class="header-right">
+        <button class="theme-toggle" id="theme-toggle" aria-label="Alternar tema">
+          <svg class="icon-sun" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="5"/><line x1="12" y1="1" x2="12" y2="3"/><line x1="12" y1="21" x2="12" y2="23"/><line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/><line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/><line x1="1" y1="12" x2="3" y2="12"/><line x1="21" y1="12" x2="23" y2="12"/><line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/><line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/></svg>
+          <svg class="icon-moon" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+        </button>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero">
+    <h1>Earnings Calendar</h1>
+    <p>Próximos reportes de resultados para los siguientes 3 meses con vista semanal o mensual.</p>
+  </section>
+
+  <main class="container">
+    <section class="section">
+      <div class="earnings-toolbar">
+        <div class="earnings-nav">
+          <button type="button" class="earnings-nav-btn" id="earnings-prev" aria-label="Periodo anterior">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+          </button>
+          <span id="earnings-period-label">-</span>
+          <button type="button" class="earnings-nav-btn" id="earnings-next" aria-label="Periodo siguiente">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </button>
+        </div>
+        <div class="earnings-view-icons" role="tablist" aria-label="Vista de calendario">
+          <button type="button" class="earnings-view-icon active" data-view="week" role="tab" aria-selected="true" title="Vista semanal">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="21" x2="9" y2="9"/></svg>
+            <span class="earnings-view-label">Semanal</span>
+          </button>
+          <button type="button" class="earnings-view-icon" data-view="month" role="tab" aria-selected="false" title="Vista mensual">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="18" height="18" rx="2"/><line x1="3" y1="9" x2="21" y2="9"/><line x1="9" y1="3" x2="9" y2="21"/><line x1="15" y1="3" x2="15" y2="21"/></svg>
+            <span class="earnings-view-label">Mensual</span>
+          </button>
+        </div>
+      </div>
+
+      <div class="loading earnings-loading" id="earnings-loading">
+        <div class="loading-spinner"></div>
+        <p>Cargando earnings...</p>
+      </div>
+      <div class="earnings-error" id="earnings-error" hidden></div>
+      <div id="earnings-calendar" hidden></div>
+      <p class="section-source" id="earnings-source"></p>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <p>Fuente: SavvyTrader earnings calendar (vía proxy interno)</p>
+    <p>Hecho con <svg style="display:inline-block;vertical-align:middle" width="14" height="14" viewBox="0 0 24 24" fill="var(--red, #e74c3c)" stroke="none"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg> desde Argentina</p>
+  </footer>
+
+  <script src="/earnings/earnings.js"></script>
+</body>
+</html>

--- a/public/index.html
+++ b/public/index.html
@@ -143,6 +143,9 @@
       <section class="section" id="section-earnings">
         <h2 class="hot-title">EARNINGS <span class="hot-subtitle">Próximos reportes de resultados</span></h2>
         <div class="earnings-timeline" id="earnings-timeline"></div>
+        <p class="section-link" style="text-align: center; margin-top: 12px;">
+          <a href="/earnings" class="view-all-link">Ver todos los earnings →</a>
+        </p>
       </section>
     </div>
 

--- a/public/styles.css
+++ b/public/styles.css
@@ -11,74 +11,84 @@
   }
 }
 
-/* Material Design Palette — Stitch-inspired */
+/* Editorial Palette — warm cream + market green */
 :root {
-  --bg: #f0f4f9;
-  --bg-subtle: #e8ecf1;
-  --card-bg: #ffffff;
-  --text: #1d1b20;
-  --text-secondary: #49454f;
-  --text-tertiary: #79747e;
-  --accent: #0b57d0;
-  --accent-light: #d3e3fd;
-  --accent-dark: #0842a0;
-  --green: #1e8e3e;
-  --green-bg: #e6f4ea;
-  --red: #d93025;
-  --red-bg: #fce8e6;
-  --border: #c4c7c5;
-  --border-light: #e1e3e1;
-  --radius: 16px;
-  --radius-sm: 12px;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
-  --shadow: 0 1px 3px rgba(0,0,0,0.12), 0 4px 8px rgba(0,0,0,0.04);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
-  --font: 'Google Sans', 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-  --font-mono: 'Google Sans Mono', 'Geist Mono', 'SF Mono', 'Fira Code', monospace;
-  --blue: #1a73e8;
-  --yellow: #f9ab00;
+  --bg: #F4EFE6;
+  --bg-subtle: #FBF7EE;
+  --card-bg: #FFFDF7;
+  --text: #16130E;
+  --text-secondary: #3C3830;
+  --text-tertiary: #807A6D;
+  --text-faint: #B8B1A2;
+  --accent: #1F6B4A;
+  --accent-light: #E6EDE6;
+  --accent-dark: #174F36;
+  --green: #1F6B4A;
+  --green-bg: #E6EDE6;
+  --red: #B8452E;
+  --red-bg: #F3E2DB;
+  --border: #CEC5B0;
+  --border-light: #E2DBCB;
+  --highlight: #E9C46A;
+  --radius: 14px;
+  --radius-sm: 6px;
+  --shadow-sm: 0 1px 0 rgba(22,19,14,.04);
+  --shadow: 0 1px 0 rgba(22,19,14,.04), 0 4px 16px rgba(22,19,14,.04);
+  --shadow-lg: 0 8px 32px rgba(22,19,14,.08);
+  --display: 'Instrument Serif', 'Newsreader', Georgia, serif;
+  --font: 'Inter Tight', 'Google Sans', 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'Google Sans Mono', 'Geist Mono', 'SF Mono', 'Fira Code', monospace;
+  --tracking-display: -0.03em;
+  --tracking-body: -0.005em;
+  --tracking-mono: 0.04em;
+  --blue: #1F6B4A;
+  --yellow: #E9C46A;
 }
 
 [data-theme="light"] {
-  --bg: #f0f4f9;
-  --bg-subtle: #e8ecf1;
-  --card-bg: #ffffff;
-  --text: #1d1b20;
-  --text-secondary: #49454f;
-  --text-tertiary: #79747e;
-  --accent: #0b57d0;
-  --accent-light: #d3e3fd;
-  --accent-dark: #0842a0;
-  --green: #1e8e3e;
-  --green-bg: #e6f4ea;
-  --red: #d93025;
-  --red-bg: #fce8e6;
-  --border: #c4c7c5;
-  --border-light: #e1e3e1;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.08), 0 1px 2px rgba(0,0,0,0.06);
-  --shadow: 0 1px 3px rgba(0,0,0,0.12), 0 4px 8px rgba(0,0,0,0.04);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.12);
+  --bg: #F4EFE6;
+  --bg-subtle: #FBF7EE;
+  --card-bg: #FFFDF7;
+  --text: #16130E;
+  --text-secondary: #3C3830;
+  --text-tertiary: #807A6D;
+  --text-faint: #B8B1A2;
+  --accent: #1F6B4A;
+  --accent-light: #E6EDE6;
+  --accent-dark: #174F36;
+  --green: #1F6B4A;
+  --green-bg: #E6EDE6;
+  --red: #B8452E;
+  --red-bg: #F3E2DB;
+  --border: #CEC5B0;
+  --border-light: #E2DBCB;
+  --highlight: #E9C46A;
+  --shadow-sm: 0 1px 0 rgba(22,19,14,.04);
+  --shadow: 0 1px 0 rgba(22,19,14,.04), 0 4px 16px rgba(22,19,14,.04);
+  --shadow-lg: 0 8px 32px rgba(22,19,14,.08);
 }
 
 [data-theme="dark"] {
-  --bg: #1b1b1f;
-  --bg-subtle: #2b2b30;
-  --card-bg: #2d2d32;
-  --text: #e6e1e5;
-  --text-secondary: #c4c0c8;
-  --text-tertiary: #938f96;
-  --accent: #a8c7fa;
-  --accent-light: #1a2740;
-  --accent-dark: #7cacf8;
-  --green: #81c995;
-  --green-bg: #1a2e1f;
-  --red: #f28b82;
-  --red-bg: #3c2020;
-  --border: #444449;
-  --border-light: #3a3a3f;
-  --shadow-sm: 0 1px 3px rgba(0,0,0,0.3);
-  --shadow: 0 2px 6px rgba(0,0,0,0.3), 0 4px 12px rgba(0,0,0,0.15);
-  --shadow-lg: 0 8px 24px rgba(0,0,0,0.4);
+  --bg: #14120F;
+  --bg-subtle: #1C1915;
+  --card-bg: #201C17;
+  --text: #EDE6D3;
+  --text-secondary: #C4BDAA;
+  --text-tertiary: #8A8372;
+  --text-faint: #5E5849;
+  --accent: #4FAE82;
+  --accent-light: #1E2C24;
+  --accent-dark: #3E9670;
+  --green: #4FAE82;
+  --green-bg: #1E2C24;
+  --red: #D46A52;
+  --red-bg: #2E1C15;
+  --border: #3A3630;
+  --border-light: #2C2822;
+  --highlight: #E9C46A;
+  --shadow-sm: 0 1px 0 rgba(0,0,0,0.4);
+  --shadow: 0 1px 0 rgba(0,0,0,0.4), 0 4px 16px rgba(0,0,0,0.3);
+  --shadow-lg: 0 8px 32px rgba(0,0,0,0.5);
 }
 
 body {
@@ -86,7 +96,21 @@ body {
   background: var(--bg);
   color: var(--text);
   line-height: 1.5;
+  letter-spacing: var(--tracking-body);
   -webkit-font-smoothing: antialiased;
+  font-feature-settings: "ss01", "cv11";
+}
+
+/* Editorial typography polish */
+h1, h2, h3, h4, h5 {
+  font-family: var(--display);
+  font-weight: 400;
+  letter-spacing: var(--tracking-display);
+  color: var(--text);
+}
+h1 em, h2 em, h3 em, h4 em, h5 em {
+  font-style: italic;
+  color: var(--accent);
 }
 
 /* Header */
@@ -2554,3 +2578,16 @@ body {
     font-size: 0.68rem;
   }
 }
+
+/* View all link for earnings section */
+.view-all-link {
+  font-size: 0.85rem;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+}
+
+.view-all-link:hover {
+  text-decoration: underline;
+}
+

--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const path = require('path');
 
 const app = express();
 const PORT = parseInt(process.env.PORT || '3000', 10);
-const PUBLIC_DIR = path.join(__dirname, 'public');
+const PUBLIC_DIR = path.resolve(__dirname, 'public');
 const CONFIG_PATH = path.join(PUBLIC_DIR, 'config.json');
 
 app.disable('x-powered-by');
@@ -30,11 +30,44 @@ app.use((req, res, next) => {
   next();
 });
 
+function sendPublicIndex(res, ...segments) {
+  const filePath = path.join(PUBLIC_DIR, ...segments);
+  if (!fs.existsSync(filePath)) {
+    return res.status(404).send('Not Found');
+  }
+  const html = fs.readFileSync(filePath, 'utf-8');
+  res.type('html').send(html);
+}
+
 app.get('/cedears', (req, res) => {
-  res.sendFile(path.join(PUBLIC_DIR, 'cedears', 'index.html'));
+  sendPublicIndex(res, 'cedears', 'index.html');
+});
+
+app.get('/cedears/', (req, res) => {
+  sendPublicIndex(res, 'cedears', 'index.html');
+});
+
+app.get('/earnings', (req, res) => {
+  sendPublicIndex(res, 'earnings', 'index.html');
+});
+
+app.get('/earnings/', (req, res) => {
+  sendPublicIndex(res, 'earnings', 'index.html');
 });
 
 app.use(express.static(PUBLIC_DIR));
+
+// Fallback: si express.static no delega o falta la ruta anterior, servir los HTML estáticos.
+app.use((req, res, next) => {
+  if (req.method !== 'GET') return next();
+  const bare = {
+    '/cedears': ['cedears', 'index.html'],
+    '/earnings': ['earnings', 'index.html'],
+  };
+  const segments = bare[req.path];
+  if (segments) return sendPublicIndex(res, ...segments);
+  next();
+});
 
 // --- Config API ---
 

--- a/vercel.json
+++ b/vercel.json
@@ -3,6 +3,7 @@
   "outputDirectory": "public",
   "rewrites": [
     { "source": "/cedears", "destination": "/cedears/index.html" },
+    { "source": "/earnings", "destination": "/earnings/index.html" },
     { "source": "/api/fci", "destination": "/api/cafci" },
     { "source": "/api/cafci/ficha/:fondoId/:claseId", "destination": "/api/cafci-ficha?fondoId=:fondoId&claseId=:claseId" },
     { "source": "/api/config", "destination": "/config.json" }


### PR DESCRIPTION
## Summary
- add a dedicated `/earnings` page with weekly/monthly calendar views and earnings day grouping
- improve earnings cards with before-open/after-close sections, IPO badges, responsive logo grids, and avatar fallbacks
- simplify home navigation by removing the top-nav Earnings tab and adding a `Ver todos los earnings ->` link under the home earnings section

## Test plan
- [x] Open `/earnings` and verify weekly/monthly toggles render correctly
- [x] Verify weekend days are hidden from weekly and monthly calendars
- [x] Verify logo fallback renders ticker text when image fails
- [x] Verify tooltip on avatar hover shows ticker and market cap
- [x] Open `/` and verify top navigation no longer shows Earnings
- [x] Verify home earnings section contains `Ver todos los earnings ->` link to `/earnings`

<img width="1658" height="1300" alt="CleanShot 2026-04-20 at 22 04 55@2x" src="https://github.com/user-attachments/assets/1b99825a-9401-45b3-9751-37ab740dffca" />
