### PR TITLE
feat(fci): add support for variable funds

### DIFF
--- a/api/cafci.js
+++ b/api/cafci.js
@@ -1,14 +1,35 @@
+function fciVariableEntityKey(row) {
+  return String((row && (row.nombre || row.fondo)) || '').trim();
+}
+
+function fciVariableInstitutionLabel(row) {
+  const key = fciVariableEntityKey(row);
+  if (!key) return '—';
+  const u = key.toUpperCase();
+  if (u === 'GLOBAL66') return 'Global66';
+  return key;
+}
+
+function fciVariableProductNombre(row) {
+  const label = fciVariableInstitutionLabel(row);
+  const raw = fciVariableEntityKey(row);
+  const fund = String(row.fondo || '').trim();
+  if (row.nombre && fund && fund.toUpperCase() !== raw.toUpperCase()) return `${label} · ${fund}`;
+  return label;
+}
+
 export default async function handler(req, res) {
   res.setHeader('Content-Type', 'application/json');
   res.setHeader('Access-Control-Allow-Origin', '*');
   res.setHeader('Cache-Control', 'public, max-age=300');
 
   try {
-    const [mmLatest, mmPrevious, rmLatest, rmPrevious] = await Promise.all([
+    const [mmLatest, mmPrevious, rmLatest, rmPrevious, variablesUltimo] = await Promise.all([
       fetchJSON('https://api.argentinadatos.com/v1/finanzas/fci/mercadoDinero/ultimo'),
       fetchJSON('https://api.argentinadatos.com/v1/finanzas/fci/mercadoDinero/penultimo'),
       fetchJSON('https://api.argentinadatos.com/v1/finanzas/fci/rentaMixta/ultimo'),
       fetchJSON('https://api.argentinadatos.com/v1/finanzas/fci/rentaMixta/penultimo'),
+      fetchJSON('https://api.argentinadatos.com/v1/finanzas/fci/variables/ultimo').catch(() => []),
     ]);
 
     // Tag each fund with its source category so clients can filter cleanly
@@ -41,6 +62,25 @@ export default async function handler(req, res) {
         patrimonio: fund.patrimonio,
         fechaDesde: prev.fecha,
         fechaHasta: fund.fecha,
+      });
+    }
+
+    const variableRows = Array.isArray(variablesUltimo) ? variablesUltimo : [];
+    for (const row of variableRows) {
+      if (!row || row.tna == null || !Number.isFinite(Number(row.tna)) || !row.fecha) continue;
+      if (!fciVariableEntityKey(row)) continue;
+      const nombre = fciVariableProductNombre(row);
+      const tnaPct = Math.round(Number(row.tna) * 100 * 100) / 100;
+      results.push({
+        nombre,
+        category: 'variables',
+        tna: tnaPct,
+        patrimonio: null,
+        fechaDesde: row.fecha,
+        fechaHasta: row.fecha,
+        tipo: row.tipo,
+        condicionesCorto: row.condicionesCorto,
+        entidad: fciVariableInstitutionLabel(row),
       });
     }
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "server.js",
   "scripts": {
     "start": "node server.js",
-    "test": "node --check server.js && node --check api/cafci.js && node --test test/"
+    "test": "node --check server.js && node --check api/cafci.js && node --test test/tna.test.js"
   },
   "keywords": [],
   "author": "",

--- a/public/app.js
+++ b/public/app.js
@@ -265,6 +265,7 @@ const ENTITY_LOGOS = {
   "Delta": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyOCAyOCIgc3R5bGU9IndpZHRoOiA0MHB4OyBoZWlnaHQ6IDQwcHg7Ij48cmVjdCB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIGZpbGw9IiMwOTQxYTUiLz48cGF0aCBkPSJNMTcuODcsOS43M2MtMS4yMS4zLTIuNDMuNi0zLjY0LjktMi4zNC41OC00LjY5LDEuMTUtNy4wMiwxLjc2LS41My4xNC0uNzEuMDYtLjctLjUxLjAyLTEuNTkuMDItMy4xOCwwLTQuNzcsMC0uNS4xOC0uNjMuNjUtLjYyLDIuNDkuMDIsNC45OC0uMDIsNy40Ny4wMiwzLjQ0LjA1LDYuMywyLjY2LDYuNzgsNi4xMi4zNiwyLjY0LS4xOSw1LTIuMTIsNi45Mi0xLjI4LDEuMjgtMi44OCwxLjkxLTQuNjcsMS45NC0yLjQuMDQtNC44LjAxLTcuMTksMC0uMTksMC0uMzgtLjEtLjU2LS4xNS4xLS4xOS4xNy0uNDEuMzEtLjU2LDMuNDUtMy40Niw2LjkxLTYuOTIsMTAuMzYtMTAuMzguMTYtLjE2LjMtLjM1LjQ2LS41Mi0uMDMtLjA1LS4wNy0uMS0uMS0uMTZaIiBmaWxsPSIjZmZmIi8+PC9zdmc+",
   "Carrefour Banco": "https://api.argentinadatos.com/static/logos/carrefour-banco.png",
   "Mercado Fondo": "https://api.argentinadatos.com/static/logos/mercado-pago.png",
+  "Global66": "https://api.argentinadatos.com/static/logos/global66.svg",
   "LB Finanzas": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTggMTgiPgogIDxyZWN0IHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgc3R5bGU9ImZpbGw6ICM1MjIzOTg7Ii8+CiAgPGc+CiAgICA8cGF0aCBkPSJNNi43MSw3Ljc3bC4zOS40OWMuNTIuNjQsMS4xMS45NiwxLjc1Ljk2LDEuMTksMCwyLjI3LTEuMTIsMi4zOS0xLjMxLDAsLjAyLDAsMCwuMDMtLjA1LTEuNDUtLjkyLTIuODktMS44NC00LjMzLTIuNzctLjI0LS4xNS0uNDgtLjIzLS43Mi0uMDUtLjI0LjE5LS4yMi40My0uMTQuNy4yMi42OC40MywxLjM1LjYzLDIuMDNaIiBzdHlsZT0iZmlsbDogI2ZmZjsiLz4KICAgIDxwYXRoIGQ9Ik0xMiw5LjExYzAsLjM2LS4yLjctLjUxLjg4LTEuNDcuOTUtMi45NiwxLjg5LTQuNDMsMi44NC0uMDcuMDUtLjE0LjA5LS4yMi4xNC0uMTguMTQtLjQ0LjE0LS42MiwwLS4xOS0uMTQtLjI2LS4zOS0uMTgtLjYxLjExLS40LjIzLS43OS4zNi0xLjE5LjE4LS41Ny4zOC0xLjEyLjUtMS43LjA3LS4zLjA3LS42MSwwLS45MSwyLjExLDIuNTksNC42OS0uMzYsNC41OS0uNDMuMzQuMjIuNTEuNTMuNTEuOThaIiBzdHlsZT0iZmlsbDogI2ZmZjsiLz4KICA8L2c+Cjwvc3ZnPg==",
   "Pellegrini": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTggMTgiPgogIDxyZWN0IHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgc3R5bGU9ImZpbGw6ICMwMDVmODY7Ii8+CiAgPGc+CiAgICA8cGF0aCBkPSJNOSw0Yy0yLjc2LDAtNSwyLjI0LTUsNXMyLjI0LDUsNSw1LDUtMi4yNCw1LTUtMi4yNC01LTUtNVpNMTEuODIsMTEuOXMwLC4wMS0uMDEuMDFoLTUuNnMtLjAxLDAtLjAxLS4wMXYtLjU2czAtLjAxLjAxLS4wMWg1LjZzLjAxLDAsLjAxLjAxdi41NmgwWk04LjA0LDEwLjQzdi0yLjg0aC42NHYyLjg0aC42M3YtMi44NGguNjR2Mi44NGguNjR2LTIuODRoLjY0djIuODRoLjI5di41OHMwLC4wMS0uMDEuMDFoLTUuMDJzLS4wMSwwLS4wMS0uMDF2LS41OGguMjh2LTIuODRoLjY0djIuODRoLjY0LDBaTTEyLjAxLDYuOTlsLS4xOC4zMXMtLjAyLjAyLS4wMy4wMmgtNS41OXMtLjAyLDAtLjAzLS4wMmwtLjE4LS4zMXMwLS4wMiwwLS4wM2wyLjk4LTEuNThzLjAzLDAsLjA0LDBsMi45OCwxLjU4cy4wMS4wMiwwLC4wM2gwWiIgc3R5bGU9ImZpbGw6ICNmZmY7Ii8+CiAgICA8cGF0aCBkPSJNMTAuNDQsNi43OGwtMS40LS42OHMtLjAyLS4wMS0uMDMtLjAxYzAsMC0uMDIsMC0uMDMsMGwtMS40Mi42OXMwLDAsMCwwaDIuODhzLjAxLDAsMCwwWiIgc3R5bGU9ImZpbGw6ICNmZmY7Ii8+CiAgPC9nPgo8L3N2Zz4=",
 };
@@ -289,6 +290,7 @@ function getLogoForEntity(entidad) {
   if (lower.includes('fiwind')) return ENTITY_LOGOS['Fiwind'];
   if (lower.includes('mercado')) return ENTITY_LOGOS['Mercado Fondo'];
   if (lower.includes('pellegrini') || lower.includes('nacion') || lower.includes('nación')) return ENTITY_LOGOS['Pellegrini'];
+  if (lower.includes('global66')) return ENTITY_LOGOS['Global66'];
   return null;
 }
 
@@ -323,24 +325,43 @@ async function init() {
   }));
 
   // Build FCI cards data
-  const fciCards = fciResults.map((item, idx) => ({
-    tna: item.tna,
-    nombre: item.nombre,
-    logoSrc: getLogoForEntity(item.entidad),
-    logo: item.entidad.substring(0, 2).toUpperCase(),
-    logoBg: stringToColor(item.entidad),
-    card: createCard({
-      logo: item.entidad.substring(0, 2).toUpperCase(),
-      logoBg: stringToColor(item.entidad), logoSrc: getLogoForEntity(item.entidad),
-      name: item.nombre, entity: item.entidad,
-      tags: [
-        { text: item.categoria, type: 'category' },
-        { text: `Patrimonio: ${formatPatrimonio(item.patrimonio)}`, type: '' }
-      ],
-      rate: `${item.tna.toFixed(2)}%`, rateLabel: 'TNA',
-      rateDate: item.fechaDesde && item.fechaHasta ? `Entre ${item.fechaDesde} y ${item.fechaHasta}` : ''
-    })
-  }));
+  const fciCards = fciResults.map((item, idx) => {
+    const isVariable = item.source === 'variables';
+    const entidad = item.entidad || item.nombre;
+    const init = entidad.substring(0, 2).toUpperCase();
+    const tags = isVariable
+      ? [
+          { text: item.categoria, type: 'category' },
+          ...(item.condicionesCorto ? [{ text: item.condicionesCorto, type: '' }] : []),
+        ]
+      : [
+          { text: item.categoria, type: 'category' },
+          { text: `Patrimonio: ${formatPatrimonio(item.patrimonio)}`, type: '' },
+        ];
+    const rateDate = isVariable
+      ? (item.fechaHasta ? `Referencia ${item.fechaHasta} · ArgentinaDatos` : '')
+      : item.fechaDesde && item.fechaHasta
+        ? `Entre ${item.fechaDesde} y ${item.fechaHasta}`
+        : '';
+    return {
+      tna: item.tna,
+      nombre: item.nombre,
+      logoSrc: getLogoForEntity(entidad),
+      logo: init,
+      logoBg: stringToColor(entidad),
+      card: createCard({
+        logo: init,
+        logoBg: stringToColor(entidad),
+        logoSrc: getLogoForEntity(entidad),
+        name: item.nombre,
+        entity: entidad,
+        tags,
+        rate: `${item.tna.toFixed(2)}%`,
+        rateLabel: 'TNA',
+        rateDate,
+      }),
+    };
+  });
 
   // Merge and sort all by TNA descending
   const all = [...garantizadosCards, ...fciCards].sort((a, b) => b.tna - a.tna);
@@ -494,7 +515,7 @@ async function fetchFCIData(activeFcis) {
     if (!data) return [];
     // Match API results to our configured funds by name
     const activeNames = new Set(activeFcis.map(f => f.nombre));
-    return data
+    const fromConfig = data
       .filter(f => activeNames.has(f.nombre))
       .map(f => {
         const cfg = activeFcis.find(c => c.nombre === f.nombre);
@@ -506,6 +527,24 @@ async function fetchFCIData(activeFcis) {
           fechaHasta: f.fechaHasta,
         };
       });
+    const variableExtras = (data || [])
+      .filter(f => f.source === 'variables' && f.nombre && f.tna > 0)
+      .map(f => ({
+        id: `var-${String(f.nombre).replace(/\s+/g, '-').toLowerCase()}`,
+        fondo_id: null,
+        clase_id: null,
+        nombre: f.nombre,
+        entidad: f.entidad || f.nombre,
+        categoria: f.categoria || 'Renta variable',
+        activo: true,
+        tna: f.tna,
+        patrimonio: f.patrimonio,
+        fechaDesde: f.fechaDesde,
+        fechaHasta: f.fechaHasta,
+        source: 'variables',
+        condicionesCorto: f.condicionesCorto,
+      }));
+    return [...fromConfig, ...variableExtras].sort((a, b) => b.tna - a.tna);
   } catch (e) {
     console.error('Error fetching FCI data:', e);
     return [];
@@ -2496,6 +2535,22 @@ async function loadInflacion() {
         id: 'fci-' + cf.id, name: cf.nombre, tna: live.tna, monthly: tnaToMonthly(live.tna),
         category: 'fcis', logo: entidad.substring(0, 2).toUpperCase(),
         logoBg: stringToColor(entidad), logoSrc: getLogoForEntity(entidad)
+      });
+    }
+
+    for (const f of fciList) {
+      if (f.source !== 'variables' || !f.nombre || !(f.tna > 0)) continue;
+      const entidad = f.entidad || f.nombre;
+      const suffix = f.condicionesCorto ? ` · ${f.condicionesCorto}` : '';
+      products.push({
+        id: 'fci-var-' + String(f.nombre).replace(/\s+/g, '-').toLowerCase(),
+        name: `${f.nombre} (variable)${suffix}`,
+        tna: f.tna,
+        monthly: tnaToMonthly(f.tna),
+        category: 'fcis',
+        logo: entidad.substring(0, 2).toUpperCase(),
+        logoBg: stringToColor(entidad),
+        logoSrc: getLogoForEntity(entidad),
       });
     }
 

--- a/public/tty.js
+++ b/public/tty.js
@@ -301,6 +301,7 @@ const ENTITY_LOGOS = {
   "Delta": "data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyOCAyOCIgc3R5bGU9IndpZHRoOiA0MHB4OyBoZWlnaHQ6IDQwcHg7Ij48cmVjdCB3aWR0aD0iMjgiIGhlaWdodD0iMjgiIGZpbGw9IiMwOTQxYTUiLz48cGF0aCBkPSJNMTcuODcsOS43M2MtMS4yMS4zLTIuNDMuNi0zLjY0LjktMi4zNC41OC00LjY5LDEuMTUtNy4wMiwxLjc2LS41My4xNC0uNzEuMDYtLjctLjUxLjAyLTEuNTkuMDItMy4xOCwwLTQuNzcsMC0uNS4xOC0uNjMuNjUtLjYyLDIuNDkuMDIsNC45OC0uMDIsNy40Ny4wMiwzLjQ0LjA1LDYuMywyLjY2LDYuNzgsNi4xMi4zNiwyLjY0LS4xOSw1LTIuMTIsNi45Mi0xLjI4LDEuMjgtMi44OCwxLjkxLTQuNjcsMS45NC0yLjQuMDQtNC44LjAxLTcuMTksMC0uMTksMC0uMzgtLjEtLjU2LS4xNS4xLS4xOS4xNy0uNDEuMzEtLjU2LDMuNDUtMy40Niw2LjkxLTYuOTIsMTAuMzYtMTAuMzguMTYtLjE2LjMtLjM1LjQ2LS41Mi0uMDMtLjA1LS4wNy0uMS0uMS0uMTZaIiBmaWxsPSIjZmZmIi8+PC9zdmc+",
   "Carrefour Banco": "https://api.argentinadatos.com/static/logos/carrefour-banco.png",
   "Mercado Fondo": "https://api.argentinadatos.com/static/logos/mercado-pago.png",
+  "Global66": "https://api.argentinadatos.com/static/logos/global66.svg",
   "LB Finanzas": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTggMTgiPgogIDxyZWN0IHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgc3R5bGU9ImZpbGw6ICM1MjIzOTg7Ii8+CiAgPGc+CiAgICA8cGF0aCBkPSJNNi43MSw3Ljc3bC4zOS40OWMuNTIuNjQsMS4xMS45NiwxLjc1Ljk2LDEuMTksMCwyLjI3LTEuMTIsMi4zOS0xLjMxLDAsLjAyLDAsMCwuMDMtLjA1LTEuNDUtLjkyLTIuODktMS44NC00LjMzLTIuNzctLjI0LS4xNS0uNDgtLjIzLS43Mi0uMDUtLjI0LjE5LS4yMi40My0uMTQuNy4yMi42OC40MywxLjM1LjYzLDIuMDNaIiBzdHlsZT0iZmlsbDogI2ZmZjsiLz4KICAgIDxwYXRoIGQ9Ik0xMiw5LjExYzAsLjM2LS4yLjctLjUxLjg4LTEuNDcuOTUtMi45NiwxLjg5LTQuNDMsMi44NC0uMDcuMDUtLjE0LjA5LS4yMi4xNC0uMTguMTQtLjQ0LjE0LS42MiwwLS4xOS0uMTQtLjI2LS4zOS0uMTgtLjYxLjExLS40LjIzLS43OS4zNi0xLjE5LjE4LS41Ny4zOC0xLjEyLjUtMS43LjA3LS4zLjA3LS42MSwwLS45MSwyLjExLDIuNTksNC42OS0uMzYsNC41OS0uNDMuMzQuMjIuNTEuNTMuNTEuOThaIiBzdHlsZT0iZmlsbDogI2ZmZjsiLz4KICA8L2c+Cjwvc3ZnPg==",
   "Pellegrini": "data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0iVVRGLTgiPz4KPHN2ZyBpZD0iTGF5ZXJfMSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMTggMTgiPgogIDxyZWN0IHdpZHRoPSIxOCIgaGVpZ2h0PSIxOCIgc3R5bGU9ImZpbGw6ICMwMDVmODY7Ii8+CiAgPGc+CiAgICA8cGF0aCBkPSJNOSw0Yy0yLjc2LDAtNSwyLjI0LTUsNXMyLjI0LDUsNSw1LDUtMi4yNCw1LTUtMi4yNC01LTUtNVpNMTEuODIsMTEuOXMwLC4wMS0uMDEuMDFoLTUuNnMtLjAxLDAtLjAxLS4wMXYtLjU2czAtLjAxLjAxLS4wMWg1LjZzLjAxLDAsLjAxLjAxdi41NmgwWk04LjA0LDEwLjQzdi0yLjg0aC42NHYyLjg0aC42M3YtMi44NGguNjR2Mi44NGguNjR2LTIuODRoLjY0djIuODRoLjI5di41OHMwLC4wMS0uMDEuMDFoLTUuMDJzLS4wMSwwLS4wMS0uMDF2LS41OGguMjh2LTIuODRoLjY0djIuODRoLjY0LDBaTTEyLjAxLDYuOTlsLS4xOC4zMXMtLjAyLjAyLS4wMy4wMmgtNS41OXMtLjAyLDAtLjAzLS4wMmwtLjE4LS4zMXMwLS4wMiwwLS4wM2wyLjk4LTEuNThzLjAzLDAsLjA0LDBsMi45OCwxLjU4cy4wMS4wMiwwLC4wM2gwWiIgc3R5bGU9ImZpbGw6ICNmZmY7Ii8+CiAgICA8cGF0aCBkPSJNMTAuNDQsNi43OGwtMS40LS42OHMtLjAyLS4wMS0uMDMtLjAxYzAsMC0uMDIsMC0uMDMsMGwtMS40Mi42OXMwLDAsMCwwaDIuODhzLjAxLDAsMCwwWiIgc3R5bGU9ImZpbGw6ICNmZmY7Ii8+CiAgPC9nPgo8L3N2Zz4=",
 };
@@ -325,6 +326,7 @@ function lookupLogoURL(name) {
   if (lower.includes('fiwind')) return ENTITY_LOGOS['Fiwind'];
   if (lower.includes('mercado')) return ENTITY_LOGOS['Mercado Fondo'];
   if (lower.includes('pellegrini') || /naci[oó]n/.test(lower)) return ENTITY_LOGOS['Pellegrini'];
+  if (lower.includes('global66')) return ENTITY_LOGOS['Global66'];
   return null;
 }
 
@@ -1400,6 +1402,20 @@ async function screenARS(main, sub) {
 
 const ARS_SUBS = {};
 
+/** ArgentinaDatos `/fci/variables/ultimo`: `nombre` entidad + `fondo` clase, o legado solo `fondo` entidad. */
+function fciVariableEntityKey(r) {
+  return String((r && (r.nombre || r.fondo)) || '').trim();
+}
+function fciVariableBarName(r) {
+  const key = fciVariableEntityKey(r);
+  if (!key) return '';
+  const u = key.toUpperCase();
+  const inst = u === 'GLOBAL66' ? 'Global66' : key;
+  const fund = String(r.fondo || '').trim();
+  if (r.nombre && fund && fund.toUpperCase() !== key.toUpperCase()) return `${inst} · ${fund}`;
+  return inst;
+}
+
 // 3a. Billeteras — cuentas remuneradas + FCIs curados (Cocos, MP, Ualá, etc.) + otros MM
 ARS_SUBS.billeteras = async function(main) {
   main.innerHTML = pHd('ars · billeteras', 'Billeteras', 'Cuentas remuneradas (tasa fija) + FCIs money market de las fintechs más populares + ranking general de money market.')
@@ -1407,15 +1423,17 @@ ARS_SUBS.billeteras = async function(main) {
     + `<section class="s"><h2><span>money market · fintechs populares</span><span class="line"></span><span class="count" id="fci-curados-count">…</span></h2><div id="fci-curados-bars"><div class="loading-row"> cargando fcis…</div></div></section>`
     + `<section class="s"><h2><span>otros money market · cafci</span><span class="line"></span><span class="count" id="fci-otros-count">…</span></h2><div id="fci-otros-bars"><div class="loading-row"> cargando resto…</div></div></section>`;
   try {
-    const [cfg, fciRes] = await Promise.all([
+    const [cfg, fciRes, varUltimo] = await Promise.all([
       fetchCached('/api/config', 120_000),
       fetchCached('/api/cafci', 300_000).catch(() => ({ data: [] })),
+      fetch('https://api.argentinadatos.com/v1/finanzas/fci/variables/ultimo').then(r => (r.ok ? r.json() : [])).catch(() => []),
     ]);
 
     // Sección 1: cuentas remuneradas (garantizados)
     const billeteras = (cfg.garantizados || []).filter(g => g.activo !== false)
       .map(g => ({ name: g.nombre, tna: +g.tna || 0, tag: g.tipo || '', limit: g.limite || '' }))
       .sort((a, b) => b.tna - a.tna);
+    const varRows = Array.isArray(varUltimo) ? varUltimo : [];
     $('#bil-count').textContent = billeteras.length;
     if (billeteras.length) {
       renderBars($('#bil-bars'), billeteras, {
@@ -1469,6 +1487,18 @@ ARS_SUBS.billeteras = async function(main) {
       otros.push({ name: base, tna: +f.tna, tag: 'cafci · money market' });
       if (otros.length >= 10) break;
     }
+    for (const r of varRows) {
+      if (!r || r.tna == null || !Number.isFinite(Number(r.tna)) || Number(r.tna) <= 0) continue;
+      const name = fciVariableBarName(r);
+      if (!name || seen.has(name)) continue;
+      seen.add(name);
+      const cc = (r.condicionesCorto || '').trim();
+      const tipo = (r.tipo || '').toLowerCase() === 'billetera' ? 'billetera' : (r.tipo || 'variable');
+      const lim = r.tope != null && r.tope > 0 ? `límite ${r.tope}` : '';
+      const tag = ['argentinadatos · ' + tipo, lim, cc].filter(Boolean).join(' · ');
+      otros.push({ name, tna: Number(r.tna) * 100, tag });
+    }
+    otros.sort((a, b) => b.tna - a.tna);
     $('#fci-otros-count').textContent = otros.length;
     if (otros.length) {
       renderBars($('#fci-otros-bars'), otros, {
@@ -1701,10 +1731,11 @@ ARS_SUBS.comparador = async function(main) {
   main.innerHTML = pHd('ars · comparador', 'Comparador', 'Billeteras, FCIs money market y plazo fijo unificados por TNA descendente.')
     + `<div id="cmp-tbl"><div class="loading-row"> cargando…</div></div>`;
   try {
-    const [cfg, fciRes, pfRes] = await Promise.all([
+    const [cfg, fciRes, pfRes, varUltimo] = await Promise.all([
       fetchCached('/api/config', 120_000),
       fetchCached('/api/cafci', 300_000).catch(() => ({ data: [] })),
       fetch('https://api.argentinadatos.com/v1/finanzas/tasas/plazoFijo').then(r => r.json()).catch(() => []),
+      fetch('https://api.argentinadatos.com/v1/finanzas/fci/variables/ultimo').then(r => (r.ok ? r.json() : [])).catch(() => []),
     ]);
     const unified = [];
     for (const g of (cfg.garantizados || [])) {
@@ -1719,6 +1750,20 @@ ARS_SUBS.comparador = async function(main) {
     const pfTop = (pfRes || []).filter(p => p.tnaClientes > 0).sort((a, b) => b.tnaClientes - a.tnaClientes).slice(0, 5);
     for (const p of pfTop) {
       unified.push({ name: shortBank(p.entidad), type: 'Plazo fijo 30d', tna: p.tnaClientes * 100, tag: '' });
+    }
+    for (const row of (Array.isArray(varUltimo) ? varUltimo : [])) {
+      if (!row || row.tna == null || !Number.isFinite(Number(row.tna))) continue;
+      const name = fciVariableBarName(row);
+      if (!name) continue;
+      const tag = [row.tipo === 'billetera' ? 'billetera' : '', (row.condicionesCorto || '').trim()]
+        .filter(Boolean)
+        .join(' · ');
+      unified.push({
+        name,
+        type: 'Renta variable',
+        tna: Number(row.tna) * 100,
+        tag,
+      });
     }
     unified.sort((a, b) => b.tna - a.tna);
 

--- a/server.js
+++ b/server.js
@@ -123,13 +123,34 @@ app.get('/api/usa-stocks', async (req, res) => {
 
 // --- FCI Data (via ArgentinaDatos) ---
 
+function fciVariableEntityKey(row) {
+  return String((row && (row.nombre || row.fondo)) || '').trim();
+}
+
+function fciVariableInstitutionLabel(row) {
+  const key = fciVariableEntityKey(row);
+  if (!key) return '—';
+  const u = key.toUpperCase();
+  if (u === 'GLOBAL66') return 'Global66';
+  return key;
+}
+
+function fciVariableProductNombre(row) {
+  const label = fciVariableInstitutionLabel(row);
+  const raw = fciVariableEntityKey(row);
+  const fund = String(row.fondo || '').trim();
+  if (row.nombre && fund && fund.toUpperCase() !== raw.toUpperCase()) return `${label} · ${fund}`;
+  return label;
+}
+
 app.get('/api/fci', async (req, res) => {
   try {
-    const [mmLatest, mmPrevious, rmLatest, rmPrevious] = await Promise.all([
+    const [mmLatest, mmPrevious, rmLatest, rmPrevious, variablesUltimo] = await Promise.all([
       fetch('https://api.argentinadatos.com/v1/finanzas/fci/mercadoDinero/ultimo').then(r => r.json()),
       fetch('https://api.argentinadatos.com/v1/finanzas/fci/mercadoDinero/penultimo').then(r => r.json()),
       fetch('https://api.argentinadatos.com/v1/finanzas/fci/rentaMixta/ultimo').then(r => r.json()),
       fetch('https://api.argentinadatos.com/v1/finanzas/fci/rentaMixta/penultimo').then(r => r.json()),
+      fetch('https://api.argentinadatos.com/v1/finanzas/fci/variables/ultimo').then(r => r.json()).catch(() => []),
     ]);
     const filterValid = d => d.filter(x => x.fecha && x.vcp);
     const allLatest = [...filterValid(mmLatest), ...filterValid(rmLatest)];
@@ -145,6 +166,27 @@ app.get('/api/fci', async (req, res) => {
       const tna = Math.round(((fund.vcp - prev.vcp) / prev.vcp / days) * 365 * 100 * 100) / 100;
       results.push({ nombre: fund.fondo, tna, patrimonio: fund.patrimonio, fechaDesde: prev.fecha, fechaHasta: fund.fecha });
     }
+
+    const variableRows = Array.isArray(variablesUltimo) ? variablesUltimo : [];
+    for (const row of variableRows) {
+      if (!row || row.tna == null || !Number.isFinite(Number(row.tna)) || !row.fecha) continue;
+      if (!fciVariableEntityKey(row)) continue;
+      const entidad = fciVariableInstitutionLabel(row);
+      const nombre = fciVariableProductNombre(row);
+      const tnaPct = Math.round(Number(row.tna) * 100 * 100) / 100;
+      results.push({
+        nombre,
+        tna: tnaPct,
+        patrimonio: null,
+        fechaDesde: row.fecha,
+        fechaHasta: row.fecha,
+        source: 'variables',
+        entidad,
+        categoria: row.tipo === 'billetera' ? 'Renta variable (billetera)' : 'Renta variable',
+        condicionesCorto: row.condicionesCorto || undefined,
+      });
+    }
+
     res.json({ data: results });
   } catch (err) {
     console.error('FCI proxy error:', err.message);


### PR DESCRIPTION
Incluye los fondos del nuevo endpoint [FCI Variables](https://argentinadatos.com/docs/operations/get-finanzas-fci-variables-fecha.html) para incluir otros fondos aún no reportados en CAFCI.

<img width="1298" height="149" alt="image" src="https://github.com/user-attachments/assets/77ef0e3a-24d5-4b89-97f7-6be64c81246f" />
