### PR TITLE
fix(deps): bump path-to-regexp 8.3.0 → 8.4.2 (ReDoS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Security
+
+- Bump `path-to-regexp` from 8.3.0 to 8.4.2 to address a high-severity backtracking ReDoS advisory ([GHSA-9wv6-86v2-598j](https://github.com/advisories/GHSA-9wv6-86v2-598j)). Transitive dependency of Express; affects only the local development server.
+
+[Unreleased]: https://github.com/arisbdar/rendimientos-ar/compare/main...HEAD

--- a/package-lock.json
+++ b/package-lock.json
@@ -582,9 +582,9 @@
       }
     },
     "node_modules/path-to-regexp": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.3.0.tgz",
-      "integrity": "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==",
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",


### PR DESCRIPTION
## Summary
- Bump de `path-to-regexp` a 8.4.2 vía `npm audit fix`
- Corrige [GHSA-9wv6-86v2-598j](https://github.com/advisories/GHSA-9wv6-86v2-598j) (Backtracking ReDoS, high severity)
- Dependencia transitiva de Express; afecta sólo al server local
- Agrega `CHANGELOG.md` siguiendo la convención [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)

## Test plan
- [x] `npm install` corre limpio
- [x] `npm audit` reporta 0 vulnerabilities
- [x] `npm start` levanta el server local en :3000 sin errores